### PR TITLE
Fix scopes for TestBench dependencies

### DIFF
--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -103,11 +103,6 @@
                 <artifactId>flow-spring-boot-starter</artifactId>
                 <version>${flow.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-html-components-testbench</artifactId>
-                <version>${flow.version}</version>
-            </dependency>
             <!-- SLF4J -->
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -237,6 +232,12 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-testbench-core</artifactId>
                 <version>${testbench.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-html-components-testbench</artifactId>
+                <version>${flow.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -56,24 +56,28 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench-core</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Flow HTML components -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-html-components-testbench</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Vaadin Core components -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-components-testbench</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <!-- Vaadin Board -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-board-testbench</artifactId>
+            <scope>compile</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The default scope set in the bom is "test" so that it
is correct if you include dependencies one by one, but for
vaadin-testbench, the elements need to be included as "compile"
so that they are all included as part of vaadin-testbench (which still
is always included using "test")