### PR TITLE
Create vaadin-core javadocs

### DIFF
--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
@@ -141,4 +141,30 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <includeDependencySources>true</includeDependencySources>
+                            <dependencySourceIncludes>
+                                <dependencySourceInclude>com.vaadin*</dependencySourceInclude>
+                            </dependencySourceIncludes>
+                            <!-- Don't fail on errors, there is plenty of those -->
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Creates javadocs for all direct vaadin-core dependencies.
Unfortunately `<includeDependencySources>` only creates javadocs for direct
dependencies, so using the same in `vaadin` dependency would only produce
javadocs for board and charts. (I think) Vaadin-core would have to provide a sources
jar with sources from all dependencies so that javadocs could be created.