### PR TITLE
Move version properties to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,36 @@
     <description>Vaadin Platform</description>
     <url>http://vaadin.com</url>
 
+    <properties>
+        <flow.version>1.0.0.beta9</flow.version>
+        <flow.spring.version>10.0.0.beta1</flow.spring.version>
+
+        <vaadin.button.flow.version>1.0.0.beta7</vaadin.button.flow.version>
+        <vaadin.checkbox.flow.version>1.0.0.beta6</vaadin.checkbox.flow.version>
+        <vaadin.combo.box.flow.version>1.0.0.beta9</vaadin.combo.box.flow.version>
+        <vaadin.date.picker.flow.version>1.0.0.beta10</vaadin.date.picker.flow.version>
+        <vaadin.dialog.flow.version>1.0.0.beta7</vaadin.dialog.flow.version>
+        <vaadin.form.layout.flow.version>1.0.0.beta6</vaadin.form.layout.flow.version>
+        <vaadin.grid.flow.version>1.0.0.beta10</vaadin.grid.flow.version>
+        <vaadin.icons.flow.version>1.0.0.beta5</vaadin.icons.flow.version>
+        <vaadin.iron.list.flow.version>1.0.0.beta5</vaadin.iron.list.flow.version>
+        <vaadin.list.box.flow.version>1.0.0.beta6</vaadin.list.box.flow.version>
+        <vaadin.notification.flow.version>1.0.0.beta7</vaadin.notification.flow.version>
+        <vaadin.ordered.layout.flow.version>1.0.0.beta6</vaadin.ordered.layout.flow.version>
+        <vaadin.progress.bar.flow.version>1.0.0.beta6</vaadin.progress.bar.flow.version>
+        <vaadin.radio.button.flow.version>1.0.0.beta7</vaadin.radio.button.flow.version>
+        <vaadin.split.layout.flow.version>1.0.0.beta5</vaadin.split.layout.flow.version>
+        <vaadin.tabs.flow.version>1.0.0.beta6</vaadin.tabs.flow.version>
+        <vaadin.text.field.flow.version>1.0.0.beta8</vaadin.text.field.flow.version>
+        <vaadin.upload.flow.version>1.0.0.beta9</vaadin.upload.flow.version>
+
+        <testbench.version>6.0.0.beta7</testbench.version>
+        <vaadin.components.testbench.version>1.0.0.beta3</vaadin.components.testbench.version>
+        <charts.version>6.0.0.beta3</charts.version>
+        <board.version>2.0.0.beta3</board.version>
+        <slf4j.version>1.7.25</slf4j.version>
+    </properties>
+
     <distributionManagement>
         <repository>
             <id>flow-internal-release</id>

--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -12,36 +12,6 @@
     <description>Vaadin Platform (Bill of Materials)</description>
     <url>http://vaadin.com</url>
 
-    <properties>
-        <flow.version>1.0.0.beta9</flow.version>
-        <flow.spring.version>10.0.0.beta1</flow.spring.version>
-
-        <vaadin.button.flow.version>1.0.0.beta7</vaadin.button.flow.version>
-        <vaadin.checkbox.flow.version>1.0.0.beta6</vaadin.checkbox.flow.version>
-        <vaadin.combo.box.flow.version>1.0.0.beta9</vaadin.combo.box.flow.version>
-        <vaadin.date.picker.flow.version>1.0.0.beta10</vaadin.date.picker.flow.version>
-        <vaadin.dialog.flow.version>1.0.0.beta7</vaadin.dialog.flow.version>
-        <vaadin.form.layout.flow.version>1.0.0.beta6</vaadin.form.layout.flow.version>
-        <vaadin.grid.flow.version>1.0.0.beta10</vaadin.grid.flow.version>
-        <vaadin.icons.flow.version>1.0.0.beta5</vaadin.icons.flow.version>
-        <vaadin.iron.list.flow.version>1.0.0.beta5</vaadin.iron.list.flow.version>
-        <vaadin.list.box.flow.version>1.0.0.beta6</vaadin.list.box.flow.version>
-        <vaadin.notification.flow.version>1.0.0.beta7</vaadin.notification.flow.version>
-        <vaadin.ordered.layout.flow.version>1.0.0.beta6</vaadin.ordered.layout.flow.version>
-        <vaadin.progress.bar.flow.version>1.0.0.beta6</vaadin.progress.bar.flow.version>
-        <vaadin.radio.button.flow.version>1.0.0.beta7</vaadin.radio.button.flow.version>
-        <vaadin.split.layout.flow.version>1.0.0.beta5</vaadin.split.layout.flow.version>
-        <vaadin.tabs.flow.version>1.0.0.beta6</vaadin.tabs.flow.version>
-        <vaadin.text.field.flow.version>1.0.0.beta8</vaadin.text.field.flow.version>
-        <vaadin.upload.flow.version>1.0.0.beta9</vaadin.upload.flow.version>
-
-        <testbench.version>6.0.0.beta7</testbench.version>
-        <vaadin.components.testbench.version>1.0.0.beta3</vaadin.components.testbench.version>
-        <charts.version>6.0.0.beta3</charts.version>
-        <board.version>2.0.0.beta3</board.version>
-        <slf4j.version>1.7.25</slf4j.version>
-    </properties>
-
     <distributionManagement>
         <repository>
             <id>flow-internal-release</id>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -19,18 +19,6 @@
         </repository>
     </distributionManagement>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <repositories>
         <repository>
             <id>vaadin-addons</id>
@@ -52,91 +40,111 @@
     </repositories>
 
     <dependencies>
-
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow</artifactId>
+            <version>${flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-data</artifactId>
+            <version>${flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
+            <version>${flow.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-button-flow</artifactId>
+            <version>${vaadin.button.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-checkbox-flow</artifactId>
+            <version>${vaadin.checkbox.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-combo-box-flow</artifactId>
+            <version>${vaadin.combo.box.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-date-picker-flow</artifactId>
+            <version>${vaadin.date.picker.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dialog-flow</artifactId>
+            <version>${vaadin.dialog.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-form-layout-flow</artifactId>
+            <version>${vaadin.form.layout.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-grid-flow</artifactId>
+            <version>${vaadin.grid.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-icons-flow</artifactId>
+            <version>${vaadin.icons.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-iron-list-flow</artifactId>
+            <version>${vaadin.iron.list.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-list-box-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-ordered-layout-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-progress-bar-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-radio-button-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-split-layout-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-tabs-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-text-field-flow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-upload-flow</artifactId>
+            <version>${vaadin.list.box.flow.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-notification-flow</artifactId>
+            <version>${vaadin.notification.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-ordered-layout-flow</artifactId>
+            <version>${vaadin.ordered.layout.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-progress-bar-flow</artifactId>
+            <version>${vaadin.progress.bar.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-radio-button-flow</artifactId>
+            <version>${vaadin.radio.button.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-split-layout-flow</artifactId>
+            <version>${vaadin.split.layout.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-tabs-flow</artifactId>
+            <version>${vaadin.tabs.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-text-field-flow</artifactId>
+            <version>${vaadin.text.field.flow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-upload-flow</artifactId>
+            <version>${vaadin.upload.flow.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Versions should be used both in vaadin-core and vaadin-bom
vaadin-core should not use vaadin-bom as it is part of it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/157)
<!-- Reviewable:end -->
