### PR TITLE
Move javadoc common configuration to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,4 +36,37 @@
         <developerConnection>scm:git:git@github.com:vaadin/platform.git</developerConnection>
     </scm>
 
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <includeDependencySources>true</includeDependencySources>
+                        <dependencySourceIncludes>
+                            <dependencySourceInclude>com.vaadin*</dependencySourceInclude>
+                        </dependencySourceIncludes>
+                        <!-- Don't fail on errors, there is plenty of those -->
+                        <doclint>none</doclint>
+                        <quiet>true</quiet>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>javadoc-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>aggregate-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -145,7 +145,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>javadoc-jar</id>
@@ -153,15 +152,6 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                            <dependencySourceIncludes>
-                                <dependencySourceInclude>com.vaadin*</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                            <!-- Don't fail on errors, there is plenty of those -->
-                            <doclint>none</doclint>
-                            <quiet>true</quiet>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Force execution of javadoc plugin in parent build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/158)
<!-- Reviewable:end -->
