### PR TITLE
Use testbench BOM and update to beta9

### DIFF
--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -35,7 +35,7 @@
         <vaadin.text.field.flow.version>1.0.0.beta8</vaadin.text.field.flow.version>
         <vaadin.upload.flow.version>1.0.0.beta11</vaadin.upload.flow.version>
 
-        <testbench.version>6.0.0.beta8</testbench.version>
+        <testbench.version>6.0.0.beta9</testbench.version>
         <vaadin.components.testbench.version>1.0.0.beta4</vaadin.components.testbench.version>
         <charts.version>6.0.0.beta4</charts.version>
         <board.version>2.0.0.beta4</board.version>
@@ -249,7 +249,7 @@
 
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-testbench-core</artifactId>
+                <artifactId>vaadin-testbench-bom</artifactId>
                 <version>${testbench.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
`vaadin-testbench-bom` is a new artifact that includes `vaadin-testbench-core` and the required selenium dependencies with correct versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/169)
<!-- Reviewable:end -->
