### PR TITLE
Remove Vaadin-spring-boot-starter from platform

### DIFF
--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -109,11 +109,6 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-spring-boot-starter</artifactId>
-                <version>${flow.spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
                 <version>${flow.version}</version>
             </dependency>


### PR DESCRIPTION
According to the issue https://github.com/vaadin/spring/issues/298 , `vaadin-spring-boot-starter` is using platform dependency. so it should not be included in the `vaadin-bom`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/177)
<!-- Reviewable:end -->
