### PR TITLE
Fix missing javadocs for flow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,11 @@
                     <version>3.0.0</version>
                     <configuration>
                         <includeDependencySources>true</includeDependencySources>
-                        <dependencySourceIncludes>
-                            <dependencySourceInclude>com.vaadin*</dependencySourceInclude>
-                        </dependencySourceIncludes>
-                        <!-- Don't fail on errors, there is plenty of those -->
+                        <dependencySourceExcludes>
+                            <!-- Exclude client engine since it is not user facing API -->
+                            <dependencySourceExclude>com.vaadin:flow-client</dependencySourceExclude>
+                        </dependencySourceExcludes>
+                        <!-- Don't fail on doclint errors for missing servlet artifact -->
                         <doclint>none</doclint>
                         <quiet>true</quiet>
                     </configuration>

--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -69,6 +69,11 @@
             <!-- Flow -->
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>flow</artifactId>
+                <version>${flow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-server</artifactId>
                 <version>${flow.version}</version>
             </dependency>

--- a/vaadin-bom/pom.xml
+++ b/vaadin-bom/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
@@ -67,11 +67,6 @@
                 <scope>test</scope>
             </dependency>
             <!-- Flow -->
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow</artifactId>
-                <version>${flow.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-server</artifactId>
@@ -261,7 +256,7 @@
                 <version>${vaadin.components.testbench.version}</version>
                 <scope>test</scope>
             </dependency>
-             <dependency>
+            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-charts-testbench</artifactId>
                 <version>${charts.version}</version>
@@ -285,7 +280,7 @@
                 <version>${board.version}</version>
             </dependency>
 
-            <!-- Transitive webjar dependencies, defined here for repeatable 
+            <!-- Transitive webjar dependencies, defined here for repeatable
                 builds -->
             <dependency>
                 <groupId>org.webjars.bowergithub.polymerelements</groupId>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -35,7 +35,19 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow</artifactId>
+            <artifactId>flow-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-push</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Cannot use flow dependency since aggregate javadocs are only provided for direct dependencies. flow artifact doesn't have any sourcs, so no javadocs for it. Thus, we should use direct flow-* artifacts as dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/180)
<!-- Reviewable:end -->
