### PR TITLE
Update versions.json to include latest context-menu

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -22,7 +22,7 @@
             "component": true
         },
         "vaadin-context-menu": {
-            "jsVersion": "4.0.0",
+            "jsVersion": "4.0.1",
             "component": true
         },
         "vaadin-date-picker": {


### PR DESCRIPTION
There is an important fix in latest context-menu related to correctly position it in the viewport

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/200)
<!-- Reviewable:end -->
