### PR TITLE
get rid of obsolete slf4j dependencies

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -14,7 +14,6 @@
 
     <properties>
 {{javadeps}}
-        <slf4j.version>1.7.25</slf4j.version>
     </properties>
 
     <distributionManagement>
@@ -93,33 +92,7 @@
                 <artifactId>flow-maven-plugin</artifactId>
                 <version>${flow.version}</version>
             </dependency>
-            <!-- SLF4J -->
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jcl</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
+            
             <!-- Free Components -->
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
We shouldn't need to declare external dependencies in our bom. This change is theoretically backwards incompatible, if somebody has depended on the slf4j version specified by our bom, so we should mention this in release notes.

Also we need to change bewerage buddy example, as that does exactly this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/228)
<!-- Reviewable:end -->
