### PR TITLE
Replace testbench bom with testbench-core

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -220,10 +220,9 @@
 
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-testbench-bom</artifactId>
+                <artifactId>vaadin-testbench-core</artifactId>
                 <version>${vaadin.testbench.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
This change is basically reverting #170.
By removing `vaadin-testbench-bom` `vaadin-bom` will not manage dependency versions for selenium. Discussion in spring-io/initializr#690

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/229)
<!-- Reviewable:end -->
