### PR TITLE
Update all components for V12, add Material

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,105 +8,108 @@
         },
         "vaadin-button": {
             "javaVersion": "1.0.3",
-            "jsVersion": "2.0.1",
+            "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-checkbox": {
             "javaVersion": "1.0.2",
-            "jsVersion": "2.1.1",
+            "jsVersion": "2.2.1",
             "component": true
         },
         "vaadin-combo-box": {
             "javaVersion": "1.0.5",
-            "jsVersion": "4.0.1",
+            "jsVersion": "4.2.0-alpha2",
             "component": true
         },
         "vaadin-context-menu": {
-            "jsVersion": "4.0.1",
+            "jsVersion": "4.2.0-alpha1",
             "component": true
         },
         "vaadin-date-picker": {
             "javaVersion": "1.0.4",
-            "jsVersion": "3.0.3",
+            "jsVersion": "3.2.0",
             "component": true
         },
         "vaadin-dialog": {
             "javaVersion": "1.0.2",
-            "jsVersion": "2.0.2",
+            "jsVersion": "2.2.0-alpha1",
             "component": true
         },
         "vaadin-dropdown-menu": {
-            "jsVersion": "1.0.1",
+            "jsVersion": "1.2.0-alpha1",
             "component": true
         },
         "vaadin-form-layout": {
             "javaVersion": "1.0.2",
-            "jsVersion": "2.0.1",
+            "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-grid": {
             "javaVersion": "1.0.4",
-            "jsVersion": "5.0.4",
+            "jsVersion": "5.2.0-alpha1",
             "component": true
         },
         "vaadin-icons": {
             "javaVersion": "1.0.2",
-            "jsVersion": "4.1.4",
+            "jsVersion": "4.2.0",
             "component": true
         },
         "iron-list": {
             "javaVersion": "1.0.2"
         },
         "vaadin-item": {
-            "jsVersion": "2.0.0",
+            "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-list-box": {
             "javaVersion": "1.0.3",
-            "jsVersion": "1.0.3",
+            "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-lumo-styles": {
-            "jsVersion": "1.0.0"
+            "jsVersion": "1.1.1"
+        },
+        "vaadin-material-styles": {
+            "jsVersion": "1.1.2"
         },
         "vaadin-notification": {
             "javaVersion": "1.0.2",
-            "jsVersion": "1.0.0",
+            "jsVersion": "1.2.0-alpha1",
             "component": true
         },
         "vaadin-ordered-layout": {
             "javaVersion": "1.0.2",
-            "jsVersion": "1.0.2",
+            "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-progress-bar": {
             "javaVersion": "1.0.2",
-            "jsVersion": "1.0.0",
+            "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-radio-button": {
             "javaVersion": "1.0.2",
-            "jsVersion": "1.0.1",
+            "jsVersion": "1.1.1",
             "component": true
         },
         "vaadin-split-layout": {
             "javaVersion": "1.0.2",
-            "jsVersion": "4.0.1",
+            "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-tabs": {
             "javaVersion": "1.0.2",
-            "jsVersion": "2.0.0",
+            "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-text-field": {
             "javaVersion": "1.0.3",
-            "jsVersion": "2.0.2",
+            "jsVersion": "2.1.1",
             "component": true
         },
         "vaadin-upload": {
             "javaVersion": "1.0.2",
-            "jsVersion": "4.0.0",
+            "jsVersion": "4.2.0",
             "component": true
         }
     },
@@ -116,25 +119,25 @@
         },
         "vaadin-board": {
             "javaVersion": "2.0.2",
-            "jsVersion": "2.0.0",
+            "jsVersion": "2.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-charts": {
             "javaVersion": "6.1.0",
-            "jsVersion": "6.1.0",
+            "jsVersion": "6.2.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-confirm-dialog": {
             "javaVersion": "1.0.0",
-            "jsVersion": "1.0.0",
+            "jsVersion": "1.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-cookie-consent": {
             "javaVersion": "1.0.0",
-            "jsVersion": "1.0.0",
+            "jsVersion": "1.1.0-alpha2",
             "component": true,
             "pro": true
         },

--- a/versions.json
+++ b/versions.json
@@ -118,7 +118,7 @@
             "jsVersion": "{{version}}"
         },
         "vaadin-board": {
-            "javaVersion": "2.1.0.alpha1",
+            "javaVersion": "2.0.2",
             "jsVersion": "2.1.0-alpha1",
             "component": true,
             "pro": true
@@ -136,7 +136,7 @@
             "pro": true
         },
         "vaadin-cookie-consent": {
-            "javaVersion": "1.0.0",
+            "javaVersion": "1.1.0.alpha1",
             "jsVersion": "1.1.0-alpha2",
             "component": true,
             "pro": true

--- a/versions.json
+++ b/versions.json
@@ -124,7 +124,7 @@
             "pro": true
         },
         "vaadin-charts": {
-            "javaVersion": "6.1.0",
+            "javaVersion": "6.2.0.alpha1",
             "jsVersion": "6.2.0-alpha1",
             "component": true,
             "pro": true

--- a/versions.json
+++ b/versions.json
@@ -130,13 +130,13 @@
             "pro": true
         },
         "vaadin-confirm-dialog": {
-            "javaVersion": "1.1.0.alpha1",
+            "javaVersion": "1.1.0.alpha2",
             "jsVersion": "1.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-cookie-consent": {
-            "javaVersion": "1.1.0.alpha1",
+            "javaVersion": "1.1.0.alpha2",
             "jsVersion": "1.1.0-alpha2",
             "component": true,
             "pro": true

--- a/versions.json
+++ b/versions.json
@@ -118,7 +118,7 @@
             "jsVersion": "{{version}}"
         },
         "vaadin-board": {
-            "javaVersion": "2.0.2",
+            "javaVersion": "2.1.0.alpha1",
             "jsVersion": "2.1.0-alpha1",
             "component": true,
             "pro": true
@@ -130,7 +130,7 @@
             "pro": true
         },
         "vaadin-confirm-dialog": {
-            "javaVersion": "1.0.0",
+            "javaVersion": "1.1.0.alpha1",
             "jsVersion": "1.1.0-alpha1",
             "component": true,
             "pro": true


### PR DESCRIPTION
Picked the proper versions of both free and commercial components.

Downgrades are undesirable as all the versions depend on same versions of
- `vaadin-development-mode-detector` 2.0.0
- `vaadin-usage-statistics` 2.0.0

The goal for the Components team is now to make beta versions by the end of September, and go to stable releases by the mid of October in order to make all this stuff for V12.

Note: another task would be to add P3 conversion step to platform publishing (to be done separately)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/286)
<!-- Reviewable:end -->
