### PR TITLE
Allow explicit setting of snapshot version.

### DIFF
--- a/scripts/generator/src/transformer.js
+++ b/scripts/generator/src/transformer.js
@@ -16,7 +16,7 @@ function transformVersions(versions, platformVersion, useSnapshots) {
 
 function transformPlatformVersion(versions, platformVersion) {
     const platformVersionVisitor = (key, value, parent) => {
-        if (value === '{{version}}') {
+        if (key != 'javaSnapshotVersion' && value === '{{version}}') {
             parent[key] = platformVersion;
         }
     };
@@ -28,8 +28,14 @@ function transformPlatformVersion(versions, platformVersion) {
 function transformJavaSnapshots(versions) {
     const majorMinorVersions = /(\d*?\.\d*).*/;
     const snapshotVersionVisitor = (key, value, parent) => {
-        if (key === 'javaVersion') {
+        // don't overwrite possible value set by 'javaSnapshotVersion'
+        if (key === 'javaVersion' && !(parent[key].endsWith("-SNAPSHOT"))) {
             parent[key] = value.replace(majorMinorVersions, "$1-SNAPSHOT");
+        }
+        // enforce snapshot version with 'javaSnapshotVersion'
+        // snapshot version must end with "-SNAPSHOT"
+        if (key === 'javaSnapshotVersion' && value.endsWith("-SNAPSHOT")) {
+            parent['javaVersion'] = value;
         }
     };
     const transformedVersions = Object.assign({}, versions);

--- a/scripts/generator/test/transformerTest.js
+++ b/scripts/generator/test/transformerTest.js
@@ -21,10 +21,12 @@ describe('Version transformer', function () {
         const testVersions = {
             "foo-bar": {
                 "javaVersion": "2.22",
+                "javaSnapshotVersion": "2.23-SNAPSHOT",
                 "jsVersion": "1.11"
             },
             "bar-foo": {
                 "javaVersion": "4.3.beta2",
+                "javaSnapshotVersion": "4.5-NOTSNAPSHOT",
                 "jsVersion": "5.7.beta33"
             },
 
@@ -33,7 +35,7 @@ describe('Version transformer', function () {
 
         const result = transformer.transformVersions(testVersions, "1.2.3", true);
 
-        expect(result['foo-bar'].javaVersion).to.equal("2.22-SNAPSHOT");
+        expect(result['foo-bar'].javaVersion).to.equal("2.23-SNAPSHOT");
         expect(result['foo-bar'].jsVersion).to.equal("1.11");
         expect(result['bar-foo'].javaVersion).to.equal("4.3-SNAPSHOT");
         expect(result['bar-foo'].jsVersion).to.equal("5.7.beta33");

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,8 @@
             "javaVersion": "1.1.0.beta2"
         },
         "flow-spring": {
-            "javaVersion": "10.0.3"
+            "javaVersion": "10.0.3",
+            "javaSnapshotVersion": "10.1-SNAPSHOT"
         },
         "vaadin-button": {
             "javaVersion": "1.1.0.beta1",


### PR DESCRIPTION
- Added new property 'javaSnapshotVersion' to set explicit snapshot version
- Updated tests to use 'javaSnapshotVersion' -property
- Added snapshot -version to flow-spring to enable proper snapshot version of spring
- Fixes #303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/304)
<!-- Reviewable:end -->
