### PR TITLE
Add multiplatform runtime to platform BOM

### DIFF
--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -271,6 +271,17 @@
                 <artifactId>vaadin-board-flow</artifactId>
                 <version>${vaadin.board.version}</version>
             </dependency>
+            
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>mpr-v7</artifactId>
+                <version>${mpr.v7.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>mpr-v8</artifactId>
+                <version>${mpr.v8.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/versions.json
+++ b/versions.json
@@ -177,6 +177,12 @@
         "vaadin-usage-statistics": {
             "jsVersion": "2.0.1"
         }
+        "mpr-v7": {
+            "javaVersion": "1.0.0"
+        }
+        "mpr-v8": {
+            "javaVersion": "1.1.0.alpha1"
+        }
     },
     "vaadin": {
         "vaadin-core": {

--- a/versions.json
+++ b/versions.json
@@ -176,10 +176,10 @@
         },
         "vaadin-usage-statistics": {
             "jsVersion": "2.0.1"
-        }
+        },
         "mpr-v7": {
             "javaVersion": "1.0.0"
-        }
+        },
         "mpr-v8": {
             "javaVersion": "1.1.0.alpha1"
         }


### PR DESCRIPTION
Added v7 and v8 versions of MPR. Those only belong in the platform BOM, not in vaadin nor vaadin-core dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/333)
<!-- Reviewable:end -->
