### PR TITLE
Fix the verifyBowerDependencies script to check license-checker correctly

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -194,12 +194,6 @@
             </dependency>
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
-                <artifactId>license-checker</artifactId>
-                <version>2.0.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>vaadin-list-mixin</artifactId>
                 <version>2.1.0</version>
             </dependency>

--- a/scripts/verifyBowerDependencies.sh
+++ b/scripts/verifyBowerDependencies.sh
@@ -45,7 +45,13 @@ for mavenDep in `cat "$mavenTemp"|sort`
 do 
 	name=`echo $mavenDep|cut -d: -f 1`
 	mavenVersion=`echo $mavenDep|cut -d: -f 2`
-	bowerVersion=`egrep "^$name:" "$bowerTemp"|cut -d: -f 2`
+	# This exception happens because the bower package name is vaadin-license-checker and the maven artifact of the webjar is license-checker
+	if [ "$name" = "license-checker" ]
+	then
+		bowerVersion=`egrep "^vaadin-license-checker:" "$bowerTemp"|cut -d: -f 2`
+	else
+		bowerVersion=`egrep "^$name:" "$bowerTemp"|cut -d: -f 2`
+	fi
 	if [ "$mavenVersion" != "$bowerVersion" ]
 	then
 		echo "##teamcity[testStarted name='$name']"


### PR DESCRIPTION
I also removed the `license-checker` webjar replication in vaadin-bom template. There is no problem with the enforcer (as far as I checked), so I think it's better to not repeat it.

The license-checker version mismatch actually causes a problem in Designer https://github.com/vaadin/designer/issues/1866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/337)
<!-- Reviewable:end -->
