### PR TITLE
Add package json templates

### DIFF
--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -31,8 +31,14 @@ function getResultsFilePath(filename) {
 const coreBowerTemplateFileName = getTemplateFilePath('template-vaadin-core-bower.json');
 const coreBowerResultFileName = getResultsFilePath('vaadin-core-bower.json');
 
+const corePackageTemplateFileName = getTemplateFilePath('template-vaadin-core-package.json');
+const corePackageResultFileName = getResultsFilePath('vaadin-core-package.json');
+
 const vaadinBowerTemplateFileName = getTemplateFilePath('template-vaadin-bower.json');
 const vaadinBowerResultFileName = getResultsFilePath('vaadin-bower.json');
+
+const vaadinPackageTemplateFileName = getTemplateFilePath('template-vaadin-package.json');
+const vaadinPackageResultFileName = getResultsFilePath('vaadin-package.json');
 
 const mavenBomTemplateFileName = getTemplateFilePath('template-vaadin-bom.xml');
 const mavenBomResultFileName = getResultsFilePath('vaadin-bom.xml');
@@ -50,7 +56,9 @@ if (!fs.existsSync(resultsDir)) {
 }
 
 writer.writeBower(versions.core, coreBowerTemplateFileName, coreBowerResultFileName);
+writer.writePackageJson(versions.core, corePackageTemplateFileName, corePackageResultFileName);
 writer.writeBower(versions.vaadin, vaadinBowerTemplateFileName, vaadinBowerResultFileName);
+writer.writePackageJson(versions.vaadin, vaadinPackageTemplateFileName, vaadinPackageResultFileName);
 writer.writeMaven(versions, mavenBomTemplateFileName, mavenBomResultFileName);
 writer.writeMaven(versions, mavenSpringBomTemplateFileName, mavenSpringBomResultFileName);
 writer.writeReleaseNotes(versions, releaseNotesTemplateFileName, releaseNotesResultFileName);

--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -19,6 +19,24 @@ function createBower(versions, bowerTemplate) {
 
 /**
 @param {Object} versions data object for product versions.
+@param {Object} packageJsonTemplate template data object to put versions to.
+*/
+function createPackageJson(versions, packageJsonTemplate) {
+    let jsDeps = {};
+    for (let [name, version] of Object.entries(versions)) {
+        if (version.npmName) {
+            const npmVersion = version.npmVersion || version.jsVersion;
+            jsDeps[version.npmName] = npmVersion;
+        }
+    }
+
+    packageJsonTemplate.dependencies = jsDeps;
+
+    return JSON.stringify(packageJsonTemplate, null, 2);
+}
+
+/**
+@param {Object} versions data object for product versions.
 @param {String} mavenTemplate template string to replace versions in.
 */
 function createMaven(versions, mavenTemplate) {
@@ -92,5 +110,6 @@ function createReleaseNotes(versions, releaseNoteTemplate) {
 }
 
 exports.createBower = createBower;
+exports.createPackageJson = createPackageJson;
 exports.createMaven = createMaven;
 exports.createReleaseNotes = createReleaseNotes;

--- a/scripts/generator/src/writer.js
+++ b/scripts/generator/src/writer.js
@@ -20,6 +20,20 @@ function writeBower(versions, templateFileName, outputFileName) {
 @param {String} templateFileName absolute path to template file
 @param {String} outputFileName absolute path to output file
 */
+function writePackageJson(versions, templateFileName, outputFileName) {
+    const packageJsonTemplate = require(templateFileName);
+
+    const packageJsonResult = creator.createPackageJson(versions, packageJsonTemplate);
+
+    fs.writeFileSync(outputFileName, packageJsonResult);
+    console.log(`Wrote ${outputFileName}`);
+}
+
+/**
+@param {Object} versions data object for product versions.
+@param {String} templateFileName absolute path to template file
+@param {String} outputFileName absolute path to output file
+*/
 function writeMaven(versions, templateFileName, outputFileName) {
     const mavenTemplate = fs.readFileSync(templateFileName, 'utf8');
 
@@ -44,5 +58,6 @@ function writeReleaseNotes(versions, templateFileName, outputFileName) {
 }
 
 exports.writeBower = writeBower;
+exports.writePackageJson = writePackageJson;
 exports.writeMaven = writeMaven;
 exports.writeReleaseNotes = writeReleaseNotes;

--- a/scripts/generator/templates/template-vaadin-bower.json
+++ b/scripts/generator/templates/template-vaadin-bower.json
@@ -15,7 +15,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "update-core-version.js"
   ],
   "dependencies": {}
 }

--- a/scripts/generator/templates/template-vaadin-core-bower.json
+++ b/scripts/generator/templates/template-vaadin-core-bower.json
@@ -21,7 +21,8 @@
     "**/node_modules",
     "**/bower_components",
     "**/test",
-    "**/tests"
+    "**/tests",
+    "**/vaadin-core.js"
   ],
   "dependencies": {}
 }

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -1,6 +1,5 @@
 {
   "name": "@vaadin/vaadin-core",
-  "version": "12.0.0-alpha3",
   "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -6,6 +6,9 @@
   "license": "Apache-2.0",
   "main": "vaadin-core.js",
   "dependencies": {},
+  "files": [
+    "vaadin-core.js"
+  ],
   "keywords": [
     "vaadin",
     "core",

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -1,5 +1,6 @@
 {
   "name": "@vaadin/vaadin-core",
+  "version": "",
   "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vaadin/vaadin-core",
+  "version": "12.0.0-alpha3",
+  "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {},
+  "keywords": [
+    "vaadin",
+    "core",
+    "elements",
+    "web",
+    "components",
+    "webcomponents",
+    "web-components"
+  ]
+}

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -4,8 +4,8 @@
   "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
+  "main": "vaadin-core.js",
   "dependencies": {},
-  "devDependencies": {},
   "keywords": [
     "vaadin",
     "core",

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vaadin/vaadin-core",
   "version": "",
-  "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
+  "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",
   "main": "vaadin-core.js",

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -1,5 +1,6 @@
 {
   "name": "@vaadin/vaadin",
+  "version": "",
   "description": "Vaadin Elements is an evolving set of open source custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cval-3.0)",

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vaadin/vaadin",
+  "description": "Vaadin Elements is an evolving set of open source custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
+  "author": "Vaadin Ltd",
+  "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cval-3.0)",
+  "dependencies": {},
+  "scripts": {
+    "version": "node update-core-version.js && git add bower.json"
+  },
+  "devDependencies": {},
+  "keywords": [
+    "vaadin",
+    "core",
+    "elements",
+    "web",
+    "components",
+    "webcomponents",
+    "web-components"
+  ]
+}

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vaadin/vaadin",
   "version": "",
-  "description": "Vaadin Elements is an evolving set of open source custom HTML elements, built using Polymer, for building mobile and desktop web applications in modern browsers.",
+  "description": "Vaadin Elements is an evolving set of open source custom HTML elements for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cval-3.0)",
   "dependencies": {},

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "version": "node update-core-version.js && git add bower.json"
   },
-  "devDependencies": {},
   "keywords": [
     "vaadin",
     "core",

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -5,6 +5,7 @@
   "author": "Vaadin Ltd",
   "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cval-3.0)",
   "dependencies": {},
+  "files": [],
   "scripts": {
     "version": "node update-core-version.js && git add bower.json"
   },

--- a/scripts/generator/test/creatorTest.js
+++ b/scripts/generator/test/creatorTest.js
@@ -50,6 +50,84 @@ describe('Bower creator', function () {
     });
 });
 
+describe('Package json creator', function () {
+    it('should replace dependencies with a valid npmName of npmVersions', function () {
+        const testVersions = {
+            "foo-bar": {
+                "npmName": "@foo/foo-bar",
+                "npmVersion": "3.33",
+                "javaVersion": "2.22",
+                "jsVersion": "1.11"
+            }
+        };
+
+        const testTemplate = {
+            foo: "bar",
+            dependencies: "removed"
+        };
+
+        const expectedResult = {
+            foo: "bar",
+            dependencies: {
+                "@foo/foo-bar": "3.33",
+            }
+        };
+
+        const result = creator.createPackageJson(testVersions, testTemplate);
+
+        expect(result).to.equal(JSON.stringify(expectedResult, null, 2));
+    });
+
+    it('should skip no npmName dependencies', function () {
+        const testVersions = {
+            "bar-foo": {
+                "javaVersion": "2.22",
+                "jsVersion": "3.33"
+            }
+        };
+
+        const testTemplate = {
+            foo: "bar",
+            dependencies: "removed"
+        };
+
+        const expectedResult = {
+            foo: "bar",
+            dependencies: {}
+        };
+
+        const result = creator.createPackageJson(testVersions, testTemplate);
+
+        expect(result).to.equal(JSON.stringify(expectedResult, null, 2));
+    });
+
+    it('should skip use jsVersion if npmVersion is not found', function () {
+        const testVersions = {
+            "bar-foo": {
+                "npmName": "@foo/bar-foo",
+                "javaVersion": "2.22",
+                "jsVersion": "3.33"
+            }
+        };
+
+        const testTemplate = {
+            foo: "bar",
+            dependencies: "removed"
+        };
+
+        const expectedResult = {
+            foo: "bar",
+            dependencies: {
+                "@foo/bar-foo": "3.33"
+            }
+        };
+
+        const result = creator.createPackageJson(testVersions, testTemplate);
+
+        expect(result).to.equal(JSON.stringify(expectedResult, null, 2));
+    });
+});
+
 describe('Maven creator', function () {
     it('should replace dependencies with a valid XML of Java versions', function () {
         const testVersions = {

--- a/versions.json
+++ b/versions.json
@@ -34,13 +34,13 @@
         "vaadin-combo-box": {
             "npmName": "@vaadin/vaadin-combo-box",
             "javaVersion": "1.1.0",
-            "jsVersion": "4.1.0",
+            "jsVersion": "4.2.0-alpha4",
             "component": true
         },
         "vaadin-context-menu": {
             "npmName": "@vaadin/vaadin-context-menu",
             "javaVersion": "1.1.0",
-            "jsVersion": "4.1.0",
+            "jsVersion": "4.2.0-beta2",
             "component": true
         },
         "vaadin-control-state-mixin": {
@@ -50,7 +50,12 @@
         "vaadin-date-picker": {
             "npmName": "@vaadin/vaadin-date-picker",
             "javaVersion": "1.1.0",
-            "jsVersion": "3.2.0",
+            "jsVersion": "3.3.0-beta1",
+            "component": true
+        },
+        "vaadin-time-picker": {
+            "npmName": "@vaadin/vaadin-time-picker",
+            "jsVersion": "1.1.0-alpha1",
             "component": true
         },
         "vaadin-development-mode-detector": {
@@ -60,12 +65,12 @@
         "vaadin-dialog": {
             "npmName": "@vaadin/vaadin-dialog",
             "javaVersion": "1.1.0",
-            "jsVersion": "2.1.0",
+            "jsVersion": "2.2.0-beta1",
             "component": true
         },
-        "vaadin-dropdown-menu": {
-            "npmName": "@vaadin/vaadin-dropdown-menu",
-            "jsVersion": "1.1.0",
+        "vaadin-select": {
+            "npmName": "@vaadin/vaadin-select",
+            "jsVersion": "2.0.0-beta1",
             "component": true
         },
         "vaadin-element-mixin": {
@@ -81,7 +86,7 @@
         "vaadin-grid": {
             "npmName": "@vaadin/vaadin-grid",
             "javaVersion": "2.0.0",
-            "jsVersion": "5.1.0",
+            "jsVersion": "5.2.0-beta2",
             "component": true
         },
         "vaadin-icons": {
@@ -173,7 +178,7 @@
         "vaadin-notification": {
             "npmName": "@vaadin/vaadin-notification",
             "javaVersion": "1.1.0",
-            "jsVersion": "1.1.0",
+            "jsVersion": "1.2.0-beta1",
             "component": true
         },
         "vaadin-ordered-layout": {
@@ -184,7 +189,7 @@
         },
         "vaadin-overlay": {
             "npmName": "@vaadin/vaadin-overlay",
-            "jsVersion": "3.1.1"
+            "jsVersion": "3.2.0"
         },
         "vaadin-progress-bar": {
             "npmName": "@vaadin/vaadin-progress-bar",

--- a/versions.json
+++ b/versions.json
@@ -10,12 +10,15 @@
             "javaVersion": "10.0.0.beta1"
         },
         "polymer": {
+            "npmPackageName": "@polymer/polymer",
             "jsVersion": "2.6.1"
         },
         "shadycss": {
+            "npmPackageName": "@polymer/shadycss",
             "jsVersion": "1.5.0"
         },
         "vaadin-button": {
+            "npmPackageName": "@vaadin/vaadin-button",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
@@ -26,155 +29,194 @@
             "component": true
         },
         "vaadin-combo-box": {
+            "npmPackageName": "@vaadin/vaadin-combo-box",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-context-menu": {
+            "npmPackageName": "@vaadin/vaadin-context-menu",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-control-state-mixin": {
+            "npmPackageName": "@vaadin/vaadin-control-state-mixin",
             "jsVersion": "2.1.1"
         },
         "vaadin-date-picker": {
+            "npmPackageName": "@vaadin/vaadin-date-picker",
             "javaVersion": "1.1.0",
             "jsVersion": "3.2.0",
             "component": true
         },
         "vaadin-development-mode-detector": {
+            "npmPackageName": "@vaadin/vaadin-development-mode-detector",
             "jsVersion": "2.0.0"
         },
         "vaadin-dialog": {
+            "npmPackageName": "@vaadin/vaadin-dialog",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-dropdown-menu": {
+            "npmPackageName": "@vaadin/vaadin-dropdown-menu",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-element-mixin": {
+            "npmPackageName": "@vaadin/vaadin-element-mixin",
             "jsVersion": "2.1.2"
         },
         "vaadin-form-layout": {
+            "npmPackageName": "@vaadin/vaadin-form-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-grid": {
+            "npmPackageName": "@vaadin/vaadin-grid",
             "javaVersion": "2.0.0",
             "jsVersion": "5.1.0",
             "component": true
         },
         "vaadin-icons": {
+            "npmPackageName": "@vaadin/vaadin-icons",
             "javaVersion": "1.1.0",
             "jsVersion": "4.2.0",
             "component": true
         },
         "iron-a11y-announcer": {
+            "npmPackageName": "@polymer/iron-a11y-announcer",
             "jsVersion": "2.1.0"
         },
         "iron-a11y-keys-behavior": {
+            "npmPackageName": "@polymer/iron-a11y-keys-behavior",
             "jsVersion": "2.1.1"
         },
         "iron-fit-behavior": {
+            "npmPackageName": "@polymer/iron-fit-behavior",
             "jsVersion": "2.2.1"
         },
         "iron-flex-layout": {
+            "npmPackageName": "@polymer/iron-flex-layout",
             "jsVersion": "2.0.3"
         },
         "iron-icon": {
+            "npmPackageName": "@polymer/iron-icon",
             "jsVersion": "2.1.0"
         },
         "iron-iconset-svg": {
+            "npmPackageName": "@polymer/iron-iconset-svg",
             "jsVersion": "2.2.1"
         },
         "iron-list": {
+            "npmPackageName": "@polymer/iron-list",
             "javaVersion": "1.1.0",
             "jsVersion": "2.0.19"
         },
         "iron-media-query": {
+            "npmPackageName": "@polymer/iron-media-query",
             "jsVersion": "2.1.0"
         },
         "iron-meta": {
+            "npmPackageName": "@polymer/iron-meta",
             "jsVersion": "2.1.1"
         },
         "iron-overlay-behavior": {
+            "npmPackageName": "@polymer/iron-overlay-behavior",
             "jsVersion": "2.3.4"
         },
         "iron-resizable-behavior": {
+            "npmPackageName": "@polymer/iron-resizable-behavior",
             "jsVersion": "2.1.1"
         },
         "iron-scroll-target-behavior": {
+            "npmPackageName": "@polymer/iron-scroll-target-behavior",
             "jsVersion": "2.1.1"
         },
         "vaadin-item": {
+            "npmPackageName": "@vaadin/vaadin-item",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-list-box": {
+            "npmPackageName": "@vaadin/vaadin-list-box",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-lumo-styles": {
+            "npmPackageName": "@vaadin/vaadin-lumo-styles",
             "jsVersion": "1.2.0"
         },
         "vaadin-material-styles": {
+            "npmPackageName": "@vaadin/vaadin-material-styles",
             "jsVersion": "1.2.0"
         },
         "vaadin-notification": {
+            "npmPackageName": "@vaadin/vaadin-notification",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-ordered-layout": {
+            "npmPackageName": "@vaadin/vaadin-ordered-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-overlay": {
+            "npmPackageName": "@vaadin/vaadin-overlay",
             "jsVersion": "3.1.1"
         },
         "vaadin-progress-bar": {
+            "npmPackageName": "@vaadin/vaadin-progress-bar",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-radio-button": {
+            "npmPackageName": "@vaadin/vaadin-radio-button",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.2",
             "component": true
         },
         "vaadin-split-layout": {
+            "npmPackageName": "@vaadin/vaadin-split-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-tabs": {
+            "npmPackageName": "@vaadin/vaadin-tabs",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.1",
             "component": true
         },
         "vaadin-text-field": {
+            "npmPackageName": "@vaadin/vaadin-text-field",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.2",
             "component": true
         },
         "vaadin-themable-mixin": {
+            "npmPackageName": "@vaadin/vaadin-themable-mixin",
             "jsVersion": "1.3.2"
         },
         "vaadin-upload": {
+            "npmPackageName": "@vaadin/vaadin-upload",
             "javaVersion": "1.1.0",
             "jsVersion": "4.2.1",
             "component": true
         },
         "webcomponentsjs": {
+            "npmPackageName": "@polymer/webcomponentsjs",
             "jsVersion": "1.2.6"
         },
         "vaadin-usage-statistics": {
+            "npmPackageName": "@vaadin/vaadin-usage-statistics",
             "jsVersion": "2.0.1"
         },
         "mpr-v7": {
@@ -186,27 +228,32 @@
     },
     "vaadin": {
         "vaadin-core": {
+            "npmPackageName": "@vaadin/vaadin-core",
             "jsVersion": "{{version}}"
         },
         "vaadin-board": {
+            "npmPackageName": "@vaadin/vaadin-board",
             "javaVersion": "2.1.0.alpha2",
             "jsVersion": "2.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-charts": {
+            "npmPackageName": "@vaadin/vaadin-charts",
             "javaVersion": "6.2.0.alpha2",
             "jsVersion": "6.2.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-confirm-dialog": {
+            "npmPackageName": "@vaadin/vaadin-confirm-dialog",
             "javaVersion": "1.1.0.alpha4",
             "jsVersion": "1.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-cookie-consent": {
+            "npmPackageName": "@vaadin/vaadin-cookie-consent",
             "javaVersion": "1.1.0.alpha3",
             "jsVersion": "1.1.0-alpha2",
             "component": true,

--- a/versions.json
+++ b/versions.json
@@ -227,8 +227,6 @@
             "component": true
         },
         "webcomponentsjs": {
-            "npmName": "@webcomponents/webcomponentsjs",
-            "npmVersion": "^2.0.0",
             "jsVersion": "1.2.6"
         },
         "vaadin-usage-statistics": {

--- a/versions.json
+++ b/versions.json
@@ -10,213 +10,229 @@
             "javaVersion": "10.0.0.beta1"
         },
         "polymer": {
-            "npmPackageName": "@polymer/polymer",
+            "npmName": "@polymer/polymer",
+            "npmVersion": "3.0.5",
             "jsVersion": "2.6.1"
         },
         "shadycss": {
-            "npmPackageName": "@polymer/shadycss",
+            "npmName": "@webcomponents/shadycss",
+            "npmVersion": "1.5.2",
             "jsVersion": "1.5.0"
         },
         "vaadin-button": {
-            "npmPackageName": "@vaadin/vaadin-button",
+            "npmName": "@vaadin/vaadin-button",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-checkbox": {
+            "npmName": "@vaadin/vaadin-checkbox",
             "javaVersion": "1.1.0",
             "jsVersion": "2.2.2",
             "component": true
         },
         "vaadin-combo-box": {
-            "npmPackageName": "@vaadin/vaadin-combo-box",
+            "npmName": "@vaadin/vaadin-combo-box",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-context-menu": {
-            "npmPackageName": "@vaadin/vaadin-context-menu",
+            "npmName": "@vaadin/vaadin-context-menu",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-control-state-mixin": {
-            "npmPackageName": "@vaadin/vaadin-control-state-mixin",
+            "npmName": "@vaadin/vaadin-control-state-mixin",
             "jsVersion": "2.1.1"
         },
         "vaadin-date-picker": {
-            "npmPackageName": "@vaadin/vaadin-date-picker",
+            "npmName": "@vaadin/vaadin-date-picker",
             "javaVersion": "1.1.0",
             "jsVersion": "3.2.0",
             "component": true
         },
         "vaadin-development-mode-detector": {
-            "npmPackageName": "@vaadin/vaadin-development-mode-detector",
+            "npmName": "@vaadin/vaadin-development-mode-detector",
             "jsVersion": "2.0.0"
         },
         "vaadin-dialog": {
-            "npmPackageName": "@vaadin/vaadin-dialog",
+            "npmName": "@vaadin/vaadin-dialog",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-dropdown-menu": {
-            "npmPackageName": "@vaadin/vaadin-dropdown-menu",
+            "npmName": "@vaadin/vaadin-dropdown-menu",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-element-mixin": {
-            "npmPackageName": "@vaadin/vaadin-element-mixin",
+            "npmName": "@vaadin/vaadin-element-mixin",
             "jsVersion": "2.1.2"
         },
         "vaadin-form-layout": {
-            "npmPackageName": "@vaadin/vaadin-form-layout",
+            "npmName": "@vaadin/vaadin-form-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-grid": {
-            "npmPackageName": "@vaadin/vaadin-grid",
+            "npmName": "@vaadin/vaadin-grid",
             "javaVersion": "2.0.0",
             "jsVersion": "5.1.0",
             "component": true
         },
         "vaadin-icons": {
-            "npmPackageName": "@vaadin/vaadin-icons",
+            "npmName": "@vaadin/vaadin-icons",
             "javaVersion": "1.1.0",
             "jsVersion": "4.2.0",
             "component": true
         },
         "iron-a11y-announcer": {
-            "npmPackageName": "@polymer/iron-a11y-announcer",
+            "npmName": "@polymer/iron-a11y-announcer",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.0"
         },
         "iron-a11y-keys-behavior": {
-            "npmPackageName": "@polymer/iron-a11y-keys-behavior",
+            "npmName": "@polymer/iron-a11y-keys-behavior",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.1"
         },
         "iron-fit-behavior": {
-            "npmPackageName": "@polymer/iron-fit-behavior",
+            "npmName": "@polymer/iron-fit-behavior",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.2.1"
         },
         "iron-flex-layout": {
-            "npmPackageName": "@polymer/iron-flex-layout",
+            "npmName": "@polymer/iron-flex-layout",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.0.3"
         },
         "iron-icon": {
-            "npmPackageName": "@polymer/iron-icon",
+            "npmName": "@polymer/iron-icon",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.0"
         },
         "iron-iconset-svg": {
-            "npmPackageName": "@polymer/iron-iconset-svg",
+            "npmName": "@polymer/iron-iconset-svg",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.2.1"
         },
         "iron-list": {
-            "npmPackageName": "@polymer/iron-list",
+            "npmName": "@polymer/iron-list",
+            "npmVersion": "3.0.1",
             "javaVersion": "1.1.0",
             "jsVersion": "2.0.19"
         },
         "iron-media-query": {
-            "npmPackageName": "@polymer/iron-media-query",
+            "npmName": "@polymer/iron-media-query",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.0"
         },
         "iron-meta": {
-            "npmPackageName": "@polymer/iron-meta",
+            "npmName": "@polymer/iron-meta",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.1"
         },
         "iron-overlay-behavior": {
-            "npmPackageName": "@polymer/iron-overlay-behavior",
+            "npmName": "@polymer/iron-overlay-behavior",
+            "npmVersion": "3.0.2",
             "jsVersion": "2.3.4"
         },
         "iron-resizable-behavior": {
-            "npmPackageName": "@polymer/iron-resizable-behavior",
+            "npmName": "@polymer/iron-resizable-behavior",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.1"
         },
         "iron-scroll-target-behavior": {
-            "npmPackageName": "@polymer/iron-scroll-target-behavior",
+            "npmName": "@polymer/iron-scroll-target-behavior",
+            "npmVersion": "3.0.1",
             "jsVersion": "2.1.1"
         },
         "vaadin-item": {
-            "npmPackageName": "@vaadin/vaadin-item",
+            "npmName": "@vaadin/vaadin-item",
             "jsVersion": "2.1.0",
             "component": true
         },
         "vaadin-list-box": {
-            "npmPackageName": "@vaadin/vaadin-list-box",
+            "npmName": "@vaadin/vaadin-list-box",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-lumo-styles": {
-            "npmPackageName": "@vaadin/vaadin-lumo-styles",
+            "npmName": "@vaadin/vaadin-lumo-styles",
             "jsVersion": "1.2.0"
         },
         "vaadin-material-styles": {
-            "npmPackageName": "@vaadin/vaadin-material-styles",
+            "npmName": "@vaadin/vaadin-material-styles",
             "jsVersion": "1.2.0"
         },
         "vaadin-notification": {
-            "npmPackageName": "@vaadin/vaadin-notification",
+            "npmName": "@vaadin/vaadin-notification",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-ordered-layout": {
-            "npmPackageName": "@vaadin/vaadin-ordered-layout",
+            "npmName": "@vaadin/vaadin-ordered-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-overlay": {
-            "npmPackageName": "@vaadin/vaadin-overlay",
+            "npmName": "@vaadin/vaadin-overlay",
             "jsVersion": "3.1.1"
         },
         "vaadin-progress-bar": {
-            "npmPackageName": "@vaadin/vaadin-progress-bar",
+            "npmName": "@vaadin/vaadin-progress-bar",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.0",
             "component": true
         },
         "vaadin-radio-button": {
-            "npmPackageName": "@vaadin/vaadin-radio-button",
+            "npmName": "@vaadin/vaadin-radio-button",
             "javaVersion": "1.1.0",
             "jsVersion": "1.1.2",
             "component": true
         },
         "vaadin-split-layout": {
-            "npmPackageName": "@vaadin/vaadin-split-layout",
+            "npmName": "@vaadin/vaadin-split-layout",
             "javaVersion": "1.1.0",
             "jsVersion": "4.1.0",
             "component": true
         },
         "vaadin-tabs": {
-            "npmPackageName": "@vaadin/vaadin-tabs",
+            "npmName": "@vaadin/vaadin-tabs",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.1",
             "component": true
         },
         "vaadin-text-field": {
-            "npmPackageName": "@vaadin/vaadin-text-field",
+            "npmName": "@vaadin/vaadin-text-field",
             "javaVersion": "1.1.0",
             "jsVersion": "2.1.2",
             "component": true
         },
         "vaadin-themable-mixin": {
-            "npmPackageName": "@vaadin/vaadin-themable-mixin",
+            "npmName": "@vaadin/vaadin-themable-mixin",
             "jsVersion": "1.3.2"
         },
         "vaadin-upload": {
-            "npmPackageName": "@vaadin/vaadin-upload",
+            "npmName": "@vaadin/vaadin-upload",
             "javaVersion": "1.1.0",
             "jsVersion": "4.2.1",
             "component": true
         },
         "webcomponentsjs": {
-            "npmPackageName": "@polymer/webcomponentsjs",
+            "npmName": "@webcomponents/webcomponentsjs",
+            "npmVersion": "^2.0.0",
             "jsVersion": "1.2.6"
         },
         "vaadin-usage-statistics": {
-            "npmPackageName": "@vaadin/vaadin-usage-statistics",
+            "npmName": "@vaadin/vaadin-usage-statistics",
             "jsVersion": "2.0.1"
         },
         "mpr-v7": {
@@ -228,32 +244,32 @@
     },
     "vaadin": {
         "vaadin-core": {
-            "npmPackageName": "@vaadin/vaadin-core",
+            "npmName": "@vaadin/vaadin-core",
             "jsVersion": "{{version}}"
         },
         "vaadin-board": {
-            "npmPackageName": "@vaadin/vaadin-board",
+            "npmName": "@vaadin/vaadin-board",
             "javaVersion": "2.1.0.alpha2",
             "jsVersion": "2.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-charts": {
-            "npmPackageName": "@vaadin/vaadin-charts",
+            "npmName": "@vaadin/vaadin-charts",
             "javaVersion": "6.2.0.alpha2",
             "jsVersion": "6.2.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-confirm-dialog": {
-            "npmPackageName": "@vaadin/vaadin-confirm-dialog",
+            "npmName": "@vaadin/vaadin-confirm-dialog",
             "javaVersion": "1.1.0.alpha4",
             "jsVersion": "1.1.0-alpha1",
             "component": true,
             "pro": true
         },
         "vaadin-cookie-consent": {
-            "npmPackageName": "@vaadin/vaadin-cookie-consent",
+            "npmName": "@vaadin/vaadin-cookie-consent",
             "javaVersion": "1.1.0.alpha3",
             "jsVersion": "1.1.0-alpha2",
             "component": true,

--- a/versions.json
+++ b/versions.json
@@ -167,6 +167,10 @@
             "jsVersion": "1.1.0",
             "component": true
         },
+        "vaadin-list-mixin": {
+            "npmName": "@vaadin/vaadin-list-mixin",
+            "jsVersion": "2.1.0"
+        },
         "vaadin-lumo-styles": {
             "npmName": "@vaadin/vaadin-lumo-styles",
             "jsVersion": "1.2.0"


### PR DESCRIPTION
This change is made for https://github.com/vaadin/platform/issues/290
In this PR:
* Added `npmName` and `npmVersion` for each dependencies in `versions.json`
* Added package.json templates for vaadin/vaadin-core and vaadin/vaadin repositories: these files will replace the current package.json in the corresponding repository like we are doing now with bower.json
* Add a function to generate dependencies for `package.json` using the versions declared in versions.json
    * It only adds dependencies which have `npmName`
    * It uses `npmVersion` if founded, otherwise, `jsVersion` will be used
* Update components version
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/338)
<!-- Reviewable:end -->
