### PR TITLE
Align vaadin-overlay and vaadin-grid version

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -160,7 +160,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>vaadin-overlay</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/versions.json
+++ b/versions.json
@@ -86,7 +86,7 @@
         "vaadin-grid": {
             "npmName": "@vaadin/vaadin-grid",
             "javaVersion": "2.1.0.alpha1",
-            "jsVersion": "5.2.0-beta2",
+            "jsVersion": "5.1.0",
             "component": true
         },
         "vaadin-icons": {


### PR DESCRIPTION
This PR downgrades `vaadin-grid` jsVersion since currently Flow can't support `vaadin-grid:5.2.0-beta2`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/349)
<!-- Reviewable:end -->
