### PR TITLE
Update vaadin-overlay to latest patch release

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -193,7 +193,7 @@
         },
         "vaadin-overlay": {
             "npmName": "@vaadin/vaadin-overlay",
-            "jsVersion": "3.2.0"
+            "jsVersion": "3.2.1"
         },
         "vaadin-progress-bar": {
             "npmName": "@vaadin/vaadin-progress-bar",


### PR DESCRIPTION
Delivering a fix for using `vaadin-combo-box` in nested `vaadin-dialog`.