### PR TITLE
Add breaking change detector

### DIFF
--- a/scripts/listBreakingChanges.js
+++ b/scripts/listBreakingChanges.js
@@ -55,8 +55,8 @@ const printChangesForProduct = (name, key, previousProduct, currentProduct) => {
     }
 }
 
-const printChanges = async () => {
-    const previousVersions = JSON.parse(await getUrl('https://raw.githubusercontent.com/vaadin/platform/11.0/versions.json'));
+const printChanges = async (previousVersion) => {
+    const previousVersions = JSON.parse(await getUrl(`https://raw.githubusercontent.com/vaadin/platform/${previousVersion}/versions.json`));
     
 
     for (let [key, value] of Object.entries(currentVersions.core)) {
@@ -80,5 +80,6 @@ const printChanges = async () => {
     }
 }
 
-
-printChanges();
+//so, so naive
+const previousVersion = process.argv[2] || '11.0';
+printChanges(previousVersion);

--- a/scripts/listBreakingChanges.js
+++ b/scripts/listBreakingChanges.js
@@ -1,0 +1,64 @@
+const https = require('https');
+
+const currentVersions = require('../versions.json');
+
+
+const getUrl = (url) => {
+    return new Promise((resolve, reject) => {
+        https.get(url, (resp) => {
+            let data = '';
+
+            resp.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            resp.on('end', () => {
+                resolve(data);
+            });
+        }).on("error", (err) => reject(err));
+    });
+}
+
+const versionsDiffer = (previous, current) => {
+    const majorVersionRegexp = /(\d*?)\./;  
+    const currentMajor = current.match(majorVersionRegexp)[1];    
+    const previousMajor = previous.match(majorVersionRegexp)[1];
+
+    return parseInt(currentMajor, 10) > parseInt(previousMajor, 10);
+}
+
+const printChanges = async () => {
+    const previousVersions = JSON.parse(await getUrl('https://raw.githubusercontent.com/vaadin/platform/11.0/versions.json'));
+    
+
+    for (let [key, value] of Object.entries(currentVersions.core)) {
+        if(!previousVersions.core[key]) { 
+            // console.log(`${key} didn't exist in the previous version`);
+            continue;
+        }
+
+        const currentJavaVersion = value.javaVersion;
+        const previousJavaVersion = previousVersions.core[key].javaVersion;
+
+        if(!currentJavaVersion && !previousJavaVersion) {
+            continue;
+        }
+
+        if(!currentJavaVersion && previousJavaVersion) {
+            // console.log(`${key} Java version was removed in the current version`);
+            continue;
+        }
+        
+        if(!previousJavaVersion && currentJavaVersion) {
+        //    console.log(`${key} Java version didn't exist in the previous version`);
+           continue;
+        }
+
+        if(versionsDiffer(previousJavaVersion, currentJavaVersion)) {
+            console.log(`Breaking change! Current Java version of ${key} is ${currentJavaVersion}, previous was ${previousJavaVersion}`);    
+        }
+    }
+}
+
+
+printChanges();


### PR DESCRIPTION
A quick and dirty script for comparing major versions between master and some other branch. Produces output like this:
```
> node listBreakingChanges.js     
Breaking change! Current javaVersion version of vaadin-combo-box is 2.0.0.beta2, previous was 1.0.7
Breaking change! Current jsVersion version of vaadin-development-mode-detector is 2.0.0, previous was 1.1.0-beta1
Breaking change! Current jsVersion version of vaadin-element-mixin is 2.1.2, previous was 1.1.2
Breaking change! Current javaVersion version of vaadin-grid is 2.1.0.alpha2, previous was 1.0.5
Breaking change! Current jsVersion version of vaadin-usage-statistics is 2.0.1, previous was 1.1.0-beta1
Breaking change! Current javaVersion version of vaadin-designer is 4.0.0.alpha4, previous was 3.1.2
Breaking change! Current javaVersion version of vaadin-testbench-components is 2.0.0.alpha1, previous was 1.0.0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/372)
<!-- Reviewable:end -->
