### PR TITLE
Use version directly for license-checker

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -179,7 +179,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>${vaadin.license.checker.version}</version>
+                <version>2.0.1</version>
             </dependency>
 
             <dependency>

--- a/versions.json
+++ b/versions.json
@@ -199,7 +199,6 @@
             "javaVersion": "1.0.0"
         },
         "vaadin-license-checker": {
-            "javaVersion": "2.0.1",
             "jsVersion": "2.0.1"
         }
     },


### PR DESCRIPTION
license-checker is a webjar which doesn't have snapshot version so if we put dynamic javaversion, it will fail the snapshot build.