### PR TITLE
Fix the frontend installation instruction version

### DIFF
--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -58,7 +58,7 @@ There are also full application examples available like **Bakery (Pro)** and **B
 
 ### Getting Started Manually
 
-For **frontend projects** you can get the dependencies with [Bower](https://bower.io) by running `bower install vaadin` or `bower install vaadin-core`.
+For **frontend projects** you can get the dependencies with [Bower](https://bower.io) by running `bower install vaadin#{{platform}}` or `bower install vaadin-core#{{platform}}`.
 
 For **Java projects**, an example of the necessary setup can be found from the [Project Base](https://github.com/vaadin/skeleton-starter-flow/blob/1.0.0/pom.xml#L24..L73).
 


### PR DESCRIPTION
Make sure that the frontend installation instructions use the specific platform release version, and not latest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/469)
<!-- Reviewable:end -->
