### PR TITLE
Fix IT tests v12

### DIFF
--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -129,12 +129,17 @@
             <plugin>
                 <groupId>com.saucelabs.maven.plugin</groupId>
                 <artifactId>sauce-connect-plugin</artifactId>
-                <version>2.1.23</version>
+                <version>2.1.25</version>
+                <configuration>
+                    <sauceUsername>${sauce.user}</sauceUsername>
+                    <sauceAccessKey>${sauce.sauceAccessKey}</sauceAccessKey>
+                    <options>${sauce.options}</options>
+                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>com.saucelabs</groupId>
                         <artifactId>ci-sauce</artifactId>
-                        <version>1.132</version>
+                        <version>1.138</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -38,7 +38,7 @@ public class ComponentsIT extends ParallelTest {
 
     static {
         Parameters.setGridBrowsers(
-                "ie11,firefox,chrome,safari-9,safari-10,safari,edge");
+                "ie11,firefox,chrome,safari-9,safari-10,safari-11,edge");
     }
 
     @Test


### PR DESCRIPTION
Use Safari 11 instead of 12.
Similar to https://github.com/vaadin/vaadin-login-flow/pull/26/commits/e5b67efe7cf94d58807033e7e6f98f613ba3dad5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/480)
<!-- Reviewable:end -->
