### PR TITLE
Update v12 components versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -22,19 +22,19 @@
         "vaadin-button": {
             "npmName": "@vaadin/vaadin-button",
             "javaVersion": "1.2.1",
-            "jsVersion": "2.1.1",
+            "jsVersion": "2.1.2",
             "component": true
         },
         "vaadin-checkbox": {
             "npmName": "@vaadin/vaadin-checkbox",
             "javaVersion": "1.2.0",
-            "jsVersion": "2.2.5",
+            "jsVersion": "2.2.6",
             "component": true
         },
         "vaadin-combo-box": {
             "npmName": "@vaadin/vaadin-combo-box",
             "javaVersion": "2.0.2",
-            "jsVersion": "4.2.1",
+            "jsVersion": "4.2.2",
             "component": true
         },
         "vaadin-context-menu": {
@@ -86,7 +86,7 @@
         "vaadin-grid": {
             "npmName": "@vaadin/vaadin-grid",
             "javaVersion": "2.1.5",
-            "jsVersion": "5.2.5",
+            "jsVersion": "5.2.6",
             "component": true
         },
         "vaadin-icons": {
@@ -204,7 +204,7 @@
         "vaadin-radio-button": {
             "npmName": "@vaadin/vaadin-radio-button",
             "javaVersion": "1.2.0",
-            "jsVersion": "1.1.3",
+            "jsVersion": "1.1.4",
             "component": true
         },
         "vaadin-split-layout": {


### PR DESCRIPTION
Polymer update is needed for npm especially, as otherwise when installing `@vaadin/vaadin` user will get duplicated dependencies. I recommend stop pinning Polymer for npm completely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/493)
<!-- Reviewable:end -->
