### PR TITLE
Temporarily remove RichTextEditor in Java package

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ These components provide a Java API for web components.
 | OrderedLayout | https://github.com/vaadin/vaadin-ordered-layout-flow | 
 | ProgressBar | https://github.com/vaadin/vaadin-progress-bar-flow |
 | RadioButton | https://github.com/vaadin/vaadin-radio-button-flow | 
-| RichTextEditor* | https://github.com/vaadin/vaadin-rich-text-editor-flow |
 | SplitLayout | https://github.com/vaadin/vaadin-split-layout-flow |
 | Tabs | https://github.com/vaadin/vaadin-tabs-flow |
 | TextField | https://github.com/vaadin/vaadin-text-field-flow |

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -260,12 +260,6 @@
                 <version>${vaadin.board.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-rich-text-editor-testbench</artifactId>
-                <version>${vaadin.rich.text.editor.version}</version>
-                <scope>test</scope>
-            </dependency>
 
             <dependency>
                 <groupId>com.vaadin</groupId>
@@ -304,12 +298,6 @@
                 <artifactId>vaadin-board-flow</artifactId>
                 <version>${vaadin.board.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-rich-text-editor-flow</artifactId>
-                <version>${vaadin.rich.text.editor.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>mpr-v7</artifactId>

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -58,7 +58,6 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.progressbar.ProgressBar;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
-import com.vaadin.flow.component.richtexteditor.RichTextEditor;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
 import com.vaadin.flow.component.tabs.Tab;
@@ -281,7 +280,6 @@ public class ComponentsView extends VerticalLayout {
         Crud<Entity> crud = new Crud<>(Entity.class, new BinderCrudEditor<>(
                 new Binder<>(Entity.class), new HorizontalLayout()));
 
-        RichTextEditor richTextEditor = new RichTextEditor();
         VerticalLayout components = new VerticalLayout();
         VerticalLayout layouts = new VerticalLayout();
 
@@ -305,7 +303,6 @@ public class ComponentsView extends VerticalLayout {
         components.add(upload);
         components.add(cookieConsent);
         components.add(crud);
-        components.add(richTextEditor);
 
         layouts.add(formLayout);
         layouts.add(verticalLayout);

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -31,7 +31,6 @@ import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;
 import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
 import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 import com.vaadin.flow.component.upload.testbench.UploadElement;
-import com.vaadin.flow.component.richtexteditor.testbench.RichTextEditorElement;
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.parallel.ParallelTest;
@@ -82,7 +81,6 @@ public class ComponentsIT extends ParallelTest {
         checkCustomElement($(TextAreaElement.class).first());
         checkCustomElement($(TextFieldElement.class).first());
         checkCustomElement($(UploadElement.class).first());
-        checkCustomElement($(RichTextEditorElement.class).first());
     }
 
     private void checkCustomElement(TestBenchElement element) {

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -95,13 +95,6 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- Vaadin Rich Text Editor -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-rich-text-editor-testbench</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>vaadin-crud-flow</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-rich-text-editor-flow</artifactId>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
* RichTextEditor is not OSGi compatible for now, so removing it to make the OSGi tests green.

This PR should be reverted when an OSGi compatible version comes to the platform