### PR TITLE
Generate npm-shwinkwrap.json for vaadin-core as well

### DIFF
--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -40,6 +40,9 @@ const vaadinBowerResultFileName = getResultsFilePath('vaadin-bower.json');
 const vaadinPackageTemplateFileName = getTemplateFilePath('template-vaadin-package.json');
 const vaadinPackageResultFileName = getResultsFilePath('vaadin-package.json');
 
+const coreShrinkwrapTemplateFileName = getTemplateFilePath('template-vaadin-core-shrinkwrap-package.json');
+const coreShrinkwrapResultFileName = getResultsFilePath('vaadin-core-shrinkwrap-package.json');
+
 const vaadinShrinkwrapTemplateFileName = getTemplateFilePath('template-vaadin-shrinkwrap-package.json');
 const vaadinShrinkwrapResultFileName = getResultsFilePath('vaadin-shrinkwrap-package.json');
 
@@ -66,6 +69,7 @@ writer.writeMaven(versions, mavenBomTemplateFileName, mavenBomResultFileName);
 writer.writeMaven(versions, mavenSpringBomTemplateFileName, mavenSpringBomResultFileName);
 writer.writeReleaseNotes(versions, releaseNotesTemplateFileName, releaseNotesResultFileName);
 
+writer.writePackageJson(versions.core, coreShrinkwrapTemplateFileName, coreShrinkwrapResultFileName);
 const shrinkwrap = {};
 Object.assign(shrinkwrap, versions.core);
 Object.assign(shrinkwrap, versions.vaadin);

--- a/scripts/generator/templates/template-vaadin-core-shrinkwrap-package.json
+++ b/scripts/generator/templates/template-vaadin-core-shrinkwrap-package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@vaadin/vaadin-core-shrinkwrap",
+  "version": "13.0.0",
+  "description": "Vaadin Elements is an evolving set of open source custom HTML elements for building mobile and desktop web applications in modern browsers.",
+  "author": "Vaadin Ltd",
+  "license": "Apache 2.0",
+  "dependencies": {},
+  "files": [
+    "npm-shrinkwrap.json"
+  ],
+  "keywords": [
+    "vaadin",
+    "core",
+    "elements",
+    "web",
+    "components",
+    "webcomponents",
+    "web-components"
+  ]
+}

--- a/scripts/npmShrinkwrap.sh
+++ b/scripts/npmShrinkwrap.sh
@@ -6,8 +6,18 @@ vaadinShrinkwrapNpmDir="$scriptDir"/tmp.npm.vaadin-shrinkwrap
 mkdir "$vaadinShrinkwrapNpmDir"
 cp "$scriptDir"/generator/results/vaadin-shrinkwrap-package.json "$vaadinShrinkwrapNpmDir"/package.json
 
+coreShrinkwrapNpmDir="$scriptDir"/tmp.npm.vaadin-core-shrinkwrap
+mkdir "$coreShrinkwrapNpmDir"
+cp "$scriptDir"/generator/results/vaadin-core-shrinkwrap-package.json "$coreShrinkwrapNpmDir"/package.json
+
+pushd $coreShrinkwrapNpmDir
+npm install
+npm shrinkwrap
+cp "$coreShrinkwrapNpmDir"/npm-shrinkwrap.json "$scriptDir"/generator/results/vaadin-core-npm-shrinkwrap.json
+popd
+
 pushd $vaadinShrinkwrapNpmDir
 npm install
 npm shrinkwrap
-cp "$vaadinShrinkwrapNpmDir"/npm-shrinkwrap.json "$scriptDir"/generator/results/npm-shrinkwrap.json
+cp "$vaadinShrinkwrapNpmDir"/npm-shrinkwrap.json "$scriptDir"/generator/results/vaadin-npm-shrinkwrap.json
 popd


### PR DESCRIPTION
Connected to #515

Files to be copied for releases:

### vaadin-core

- `vaadin-core-shrinkwrap-package.json` -> `package.json`
- `vaadin-core-npm-shrinkwrap.json` -> `npm-shrinkwrap.json`

### vaadin

- `vaadin-shrinkwrap-package.json` -> `package.json`
- `vaadin-npm-shrinkwrap.json` -> `npm-shrinkwrap.json`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/531)
<!-- Reviewable:end -->
