### PR TITLE
Add requireUpperBoundDeps rule

### DIFF
--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>enforce-maven-version</id>
@@ -103,6 +103,7 @@
                         <configuration>
                             <rules>
                                 <dependencyConvergence />
+                                <requireUpperBoundDeps />
                             </rules>
                         </configuration>
                         <goals>


### PR DESCRIPTION
Fixes https://github.com/vaadin/platform/issues/604

Added the require upper bound deps rule, described in http://maven.apache.org/enforcer/enforcer-rules/requireUpperBoundDeps.html. In my tests, it was able to catch the problem described in https://github.com/vaadin/platform/issues/604.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/608)
<!-- Reviewable:end -->
