### PR TITLE
Update material styles to 1.2.3

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -189,7 +189,7 @@
         },
         "vaadin-material-styles": {
             "npmName": "@vaadin/vaadin-material-styles",
-            "jsVersion": "1.2.2"
+            "jsVersion": "1.2.3"
         },
         "vaadin-menu-bar": {
             "npmName": "@vaadin/vaadin-menu-bar",


### PR DESCRIPTION
Fix for BFP https://github.com/vaadin/vaadin-material-styles/issues/85 ("Blank screen and JavaScript syntax errors in IE11 when using Material theme")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/687)
<!-- Reviewable:end -->
