### PR TITLE
Fix splitLayoutIsRendered test

### DIFF
--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -244,9 +244,11 @@ public class ComponentsView extends VerticalLayout {
 
         SplitLayout splitHorizontal = new SplitLayout(new Button("Left"),
                 new Button("Right"));
+        splitHorizontal.getStyle().set("flex", "none");
         SplitLayout splitVertical = new SplitLayout(new Button("Top"),
                 new Button("Bottom"));
         splitVertical.setOrientation(Orientation.VERTICAL);
+        splitVertical.getStyle().set("flex", "none");
 
         Tabs tabs = new Tabs();
         tabs.add(new Tab("foo"), new Tab("bar"));

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -414,7 +414,6 @@ public class ChromeComponentsIT extends ParallelTest {
     }
 
     @Test
-    @Ignore
     public void splitLayoutIsRendered() {
         SplitLayoutElement splitLayoutElement = $(SplitLayoutElement.class)
                 .first();


### PR DESCRIPTION
There is a known issue in split-layout that when it is placed in a vertical-layout it jammed and its height becomes zero. The workaround to fix it is to set `flex` CSS attribute to `none`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/695)
<!-- Reviewable:end -->
