### PR TITLE
Upgrade ci-sauce version to 1.138

### DIFF
--- a/platform-servlet-containers-tests/felix-jetty/pom.xml
+++ b/platform-servlet-containers-tests/felix-jetty/pom.xml
@@ -234,7 +234,7 @@
                     <dependency>
                         <groupId>com.saucelabs</groupId>
                         <artifactId>ci-sauce</artifactId>
-                        <version>1.132</version>
+                        <version>1.138</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
It was different from other modules and caused an error in platform build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/718)
<!-- Reviewable:end -->
