### PR TITLE
Say no to http (master)

### DIFF
--- a/platform-servlet-containers-tests/felix-jetty/pom.xml
+++ b/platform-servlet-containers-tests/felix-jetty/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <felix.version>6.0.0</felix.version>
-        <felix.distribution>http://central.maven.org/maven2/org/apache/felix/org.apache.felix.main.distribution/${felix.version}/org.apache.felix.main.distribution-${felix.version}.zip</felix.distribution>
+        <felix.distribution>https://central.maven.org/maven2/org/apache/felix/org.apache.felix.main.distribution/${felix.version}/org.apache.felix.main.distribution-${felix.version}.zip</felix.distribution>
         <felix.home>felix-framework-${felix.version}</felix.home>
     </properties>
 

--- a/platform-servlet-containers-tests/pom.xml
+++ b/platform-servlet-containers-tests/pom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
     <name>Vaadin Platform Servlet Containers Tests</name>
     <description>Vaadin Platform Servlet Containers Tests</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <version>14.0-SNAPSHOT</version>
     <name>Vaadin Platform</name>
     <description>Vaadin Platform</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <distributionManagement>
         <repository>

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
     <name>Vaadin Platform (Bill of Materials)</name>
     <description>Vaadin Platform (Bill of Materials)</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <properties>
 {{javadeps}}

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
     <name>Vaadin Spring (Bill of Materials)</name>
     <description>Vaadin Spring (Bill of Materials)</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <properties>
 {{javadeps}}

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
     <name>Vaadin Platform (vaadin-core)</name>
     <description>Vaadin Platform (vaadin-core)</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <distributionManagement>
         <repository>

--- a/vaadin-platform-javadoc/pom.xml
+++ b/vaadin-platform-javadoc/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
     <name>Vaadin Platform (vaadin-platform-javadoc)</name>
     <description>Vaadin Platform (vaadin-platform-javadoc)</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <distributionManagement>
         <repository>

--- a/vaadin-platform-test/pom-bower.xml
+++ b/vaadin-platform-test/pom-bower.xml
@@ -11,7 +11,7 @@
     <packaging>war</packaging>
     <name>Vaadin Platform Tests in Bower Mode</name>
     <description>Vaadin Platform Tests in Bower Mode</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -11,7 +11,7 @@
     <packaging>war</packaging>
     <name>Vaadin Platform Tests in NPM mode</name>
     <description>Vaadin Platform Tests in NPM mode</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -10,7 +10,7 @@
     <packaging>jar</packaging>
     <name>Vaadin Platform (vaadin)</name>
     <description>Vaadin Platform</description>
-    <url>http://vaadin.com</url>
+    <url>https://vaadin.com</url>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
- Use http when downloading felix dependency
- Use http for the vaadin.com url in pom

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/770)
<!-- Reviewable:end -->
