### PR TITLE
Remove magic number from iron list items assertion

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -242,7 +242,7 @@ public class ChromeComponentsIT extends ParallelTest {
         assertElementRendered(itemsContainer);
 
         List<TestBenchElement> items = ironList.$("span").all();
-        Assert.assertEquals(3, items.size());
+        Assert.assertFalse(items.isEmpty());
         items.stream().forEach(this::assertElementRendered);
 
         for (int i = 0; i < items.size(); i++) {


### PR DESCRIPTION
Computed height in Chrome 76 changed resulting in different number of items rendered

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/773)
<!-- Reviewable:end -->
