### PR TITLE
Add javadoc and sources plugins to vaadin and vaadin-core

### DIFF
--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -222,6 +222,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <includeDependencySources>false</includeDependencySources>
+                    <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
                     <quiet>true</quiet>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -195,6 +195,38 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <quiet>true</quiet>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
     <profiles>

--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -161,6 +161,8 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <includeDependencySources>false</includeDependencySources>
+                    <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
                     <quiet>true</quiet>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>

--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -134,6 +134,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <quiet>true</quiet>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Previously javadoc and sources jars were not required but now
vaadin and vaadin-core have a shinkwrap class and extra artifacts
are required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/791)
<!-- Reviewable:end -->
