### PR TITLE
Add entry point files for `vaadin` npm and bower artifacts (#815)

### DIFF
--- a/scripts/generator/templates/template-vaadin-bower.json
+++ b/scripts/generator/templates/template-vaadin-bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Vaadin Ltd"
   ],
-  "main": "",
+  "main": "vaadin.html",
   "license": [
     "Apache-2.0",
     "https://vaadin.com/license/cval-3.0"

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -5,7 +5,9 @@
   "author": "Vaadin Ltd",
   "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cval-3.0)",
   "dependencies": {},
-  "files": [],
+  "files": [
+    "vaadin.js"
+  ],
   "scripts": {
     "version": "node update-core-version.js && git add bower.json"
   },


### PR DESCRIPTION
This change was done and approved in https://github.com/vaadin/vaadin/pull/50
But it was overriden in following release https://github.com/vaadin/vaadin/commit/15d68d9b82adcfa28a45596e600bb5a252a46902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/823)
<!-- Reviewable:end -->
