### PR TITLE
Moved usage statistic test from starters

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.internal.WrapsElement;
@@ -548,7 +549,7 @@ public class ChromeComponentsIT extends ParallelTest {
         // wait 5 seconds for collecting values in local storage	
         Thread.sleep(5000);	
 
-        JavascriptExecutor js = (JavascriptExecutor) driver;	
+        JavascriptExecutor js = (JavascriptExecutor) driver;
         Object mode = js.executeScript("return Vaadin.developmentMode");	
 
         String item = (String) js.executeScript(	

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -541,6 +541,28 @@ public class ChromeComponentsIT extends ParallelTest {
 
         assertLog("Context menu Item 0 is clicked");
     }
+    
+    @Test	
+    public void usageStatisticIsLogged() throws InterruptedException {	
+        Assert.assertTrue($(ButtonElement.class).exists());	
+        // wait 5 seconds for collecting values in local storage	
+        Thread.sleep(5000);	
+
+        JavascriptExecutor js = (JavascriptExecutor) driver;	
+        Object mode = js.executeScript("return Vaadin.developmentMode");	
+
+        String item = (String) js.executeScript(	
+                "return window.localStorage.getItem('vaadin.statistics.basket');");	
+
+        if(Boolean.TRUE.equals(mode)){	
+            Assert.assertTrue("Under development mode, the checked usage statistics are not found",	
+                    item.contains("flow") && item.contains("java") && item.contains("vaadin-button"));	
+        } else {	
+            Assert.assertTrue("Under production mode, the usage statistics info should be empty",	
+                    (item == null || item.length() == 0));	
+        }	
+
+    }
 
     @BrowserConfiguration
     public List<DesiredCapabilities> getBrowserConfiguration() {


### PR DESCRIPTION
https://github.com/vaadin/skeleton-starter-flow/pull/255 
Fixes original issue #921 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/975)
<!-- Reviewable:end -->
