### PR TITLE
CCDM: run tests in v15

### DIFF
--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -22,7 +22,6 @@
         <osgi.bundle.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</osgi.bundle.version>
         <sauce.options>--tunnel-identifier ${maven.build.timestamp}</sauce.options>
         <ui.jar.classes>${project.build.directory}/ui-jar</ui.jar.classes>
-        <vaadin.clientSideMode>false</vaadin.clientSideMode>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -151,9 +150,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <clientSideMode>${vaadin.clientSideMode}</clientSideMode>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
@@ -163,12 +159,6 @@
                     <stopPort>9999</stopPort>
                     <stopWait>5</stopWait>
                     <stopKey>foo</stopKey>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>clientSideMode</name>
-                            <value>${vaadin.clientSideMode}</value>
-                        </systemProperty>
-                    </systemProperties>
                 </configuration>
                 <executions>
                     <execution>
@@ -404,7 +394,6 @@
                         </executions>
                         <configuration>
                             <productionMode>true</productionMode>
-                            <clientSideMode>${vaadin.clientSideMode}</clientSideMode>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Fixes: https://github.com/vaadin/platform/issues/903.Flip the flag to enable tests running in v15 clientSideMode
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/985)
<!-- Reviewable:end -->
