### PR TITLE
Update components versions for 14.1

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -365,7 +365,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.osano</groupId>
                 <artifactId>cookieconsent</artifactId>
-                <version>{{core.cookieconsent.jsVersion}}</version>
+                <version>{{vaadin.cookieconsent.jsVersion}}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/versions.json
+++ b/versions.json
@@ -41,8 +41,8 @@
         },
         "vaadin-combo-box": {
             "npmName": "@vaadin/vaadin-combo-box",
-            "javaVersion": "3.0.5",
-            "jsVersion": "5.0.8",
+            "javaVersion": "3.0.6",
+            "jsVersion": "5.0.9",
             "component": true
         },
         "vaadin-context-menu": {
@@ -329,50 +329,50 @@
         },
         "vaadin-board": {
             "npmName": "@vaadin/vaadin-board",
-            "javaVersion": "3.0.0",
-            "jsVersion": "2.1.0",
+            "javaVersion": "3.0.1",
+            "jsVersion": "2.1.1",
             "component": true,
             "pro": true
         },
         "vaadin-charts": {
             "npmName": "@vaadin/vaadin-charts",
-            "javaVersion": "7.0.1",
-            "jsVersion": "6.2.3",
+            "javaVersion": "7.0.2",
+            "jsVersion": "6.2.4",
             "component": true,
             "pro": true
         },
         "vaadin-confirm-dialog": {
             "npmName": "@vaadin/vaadin-confirm-dialog",
-            "javaVersion": "2.0.1",
-            "jsVersion": "1.1.4",
+            "javaVersion": "2.0.2",
+            "jsVersion": "1.1.5",
             "component": true,
             "pro": true
         },
         "vaadin-cookie-consent": {
             "npmName": "@vaadin/vaadin-cookie-consent",
-            "javaVersion": "2.0.1",
-            "jsVersion": "1.1.1",
+            "javaVersion": "2.0.2",
+            "jsVersion": "1.1.2",
             "component": true,
             "pro": true
         },
         "vaadin-crud": {
             "npmName": "@vaadin/vaadin-crud",
-            "javaVersion": "2.1.0.beta1",
-            "jsVersion": "1.1.0-beta1",
+            "javaVersion": "2.1.0.beta2",
+            "jsVersion": "1.1.0",
             "component": true,
             "pro": true
         },
         "vaadin-grid-pro": {
             "npmName": "@vaadin/vaadin-grid-pro",
-            "javaVersion": "2.0.2",
-            "jsVersion": "2.0.4",
+            "javaVersion": "2.0.3",
+            "jsVersion": "2.0.5",
             "component": true,
             "pro": true
         },
         "vaadin-rich-text-editor": {
             "npmName": "@vaadin/vaadin-rich-text-editor",
-            "javaVersion": "2.1.0.beta1",
-            "jsVersion": "1.1.0",
+            "javaVersion": "2.1.0",
+            "jsVersion": "1.1.1",
             "component": true,
             "pro": true
         },

--- a/versions.json
+++ b/versions.json
@@ -17,11 +17,6 @@
             "npmVersion": "1.8.0",
             "jsVersion": "1.8.0"
         },
-        "cookieconsent": {
-            "npmName": "cookieconsent",
-            "npmVersion": "3.1.0",
-            "jsVersion": "3.1.0"
-        },
         "vaadin-accordion": {
             "npmName": "@vaadin/vaadin-accordion",
             "javaVersion": "2.0.0",
@@ -204,7 +199,7 @@
         "vaadin-lumo-styles": {
             "npmName": "@vaadin/vaadin-lumo-styles",
             "jsVersion": "1.5.0",
-            "releasenotes" : true            
+            "releasenotes" : true
         },
         "vaadin-material-styles": {
             "npmName": "@vaadin/vaadin-material-styles",
@@ -390,6 +385,9 @@
         },
         "vaadin-license-checker": {
             "jsVersion": "2.1.1"
+        },
+        "cookieconsent": {
+            "jsVersion": "3.1.0"
         }
     },
     "platform": "{{version}}"


### PR DESCRIPTION
Also moved `cookieconsent` to `vaadin` as it is used by Pro component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/995)
<!-- Reviewable:end -->
