### PR TITLE
Update element-mixin version for 14.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -91,7 +91,7 @@
         },
         "vaadin-element-mixin": {
             "npmName": "@vaadin/vaadin-element-mixin",
-            "jsVersion": "2.1.4"
+            "jsVersion": "2.1.5"
         },
         "vaadin-form-layout": {
             "npmName": "@vaadin/vaadin-form-layout",


### PR DESCRIPTION
This version ensures 14.0 users don't get `vaadin-usage-statistics` 2.1.0 (so they get 2.0.x instead)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1010)
<!-- Reviewable:end -->
