### PR TITLE
Re-enable the enforcer plugin

### DIFF
--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -98,6 +98,18 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>	
+                        <id>enforce</id>	
+                        <configuration>	
+                            <rules>	
+                                <dependencyConvergence />	
+                                <requireUpperBoundDeps />	
+                            </rules>	
+                        </configuration>	
+                        <goals>	
+                            <goal>enforce</goal>	
+                        </goals>	
+                    </execution>
                 </executions>
             </plugin>
             <!-- compute shrink version -->


### PR DESCRIPTION
As the referred PR in #944 has been released with flow 3.0.0.alpha8
we should re-enable the enforce plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1021)
<!-- Reviewable:end -->
