### PR TITLE
Update spring-boot version to 2.2.0.RELEASE

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -40,7 +40,7 @@
     </repositories>
 
     <properties>
-        <spring-boot.version>2.1.0.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Picked from `14.1` branch update
This version is used for `>spring-boot-starter-web<`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1027)
<!-- Reviewable:end -->
