### PR TITLE
Update browser support release notes for V15

### DIFF
--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -120,14 +120,12 @@ Development is supported with the following operating systems, for any OS versio
       - X.Org 1.0 or higher (1.7 or higher is recommended)
       - libstdc++ 4.6.1 or higher
     - Latest Firefox ESR is supported (starting from Firefox ESR 68)
-  - Safari on macOS 10.14 Mojave or later
+  - Safari on macOS 10.15 or later (starting from Safari 13, available also for macOS 10.14.5 and 10.13.6)
   - Edge on Windows 10 or later
-- Internet Explorer 11 on Windows 7, Windows 8 and Windows 10
-  - (see _Known Issues and Limitations_ below)  
 
 ## Mobile Browsers
 The following built-in browsers in the following mobile operating systems:
-- Safari starting from iOS 12.0
+- Safari starting from iOS 13
 - Google Chrome evergreen on Android (requiring Android 4.4 or newer)
 
 ## Development environments


### PR DESCRIPTION
Removed IE11 and adjusted Safari support to version 13.

Part of vaadin/flow#6856

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1096)
<!-- Reviewable:end -->
