### PR TITLE
Update button and overlay versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -26,7 +26,7 @@
         "vaadin-button": {
             "npmName": "@vaadin/vaadin-button",
             "javaVersion": "3.0.0.alpha1",
-            "jsVersion": "2.2.1",
+            "jsVersion": "2.2.2",
             "component": true
         },
         "vaadin-checkbox": {
@@ -227,7 +227,7 @@
         },
         "vaadin-overlay": {
             "npmName": "@vaadin/vaadin-overlay",
-            "jsVersion": "3.2.17",
+            "jsVersion": "3.2.18",
             "releasenotes": true
         },
         "vaadin-progress-bar": {


### PR DESCRIPTION
This should help to get rid of duplicated dependencies problem.

The main cause is that `vaadin-button-flow` 3.0.0.alpha1 is released with `2.2.2` but the version specified on master is incorrectly set to `2.2.1` which results in duplicate button versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1116)
<!-- Reviewable:end -->
