### PR TITLE
Make compiler-plugin to use source/target level 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
     <name>Vaadin Platform</name>
     <description>Vaadin Platform</description>
     <url>https://vaadin.com</url>
+    
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
 
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <url>https://vaadin.com</url>
     
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Current master build failed on JDK 10 and later, this is caused by using `maven-compiler-plugin` version:3.1 (this is the default version used in TC, check from https://bender.vaadin.com/viewLog.html?buildId=120679&buildTypeId=VaadinPlatform_ReleasePlatformSnapshotOracleJdk11&tab=buildLog&branch_VaadinPlatform_PlatformSnapshotJDKsTesting=%3Cdefault%3E&_focus=551.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1130)
<!-- Reviewable:end -->
