### PR TITLE
Make compiler-plugin to use source/target level 8 (#1130)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
     <name>Vaadin Platform</name>
     <description>Vaadin Platform</description>
     <url>https://vaadin.com</url>
+    
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
* Make compiler-plugin to use source/target level 6

Current master build failed on JDK 10 and later, this is caused by using `maven-compiler-plugin` 3.1 (this is the default version.)

* Update version to 1.8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1134)
<!-- Reviewable:end -->
