### PR TITLE
Update template-vaadin-bom.xml

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -336,11 +336,6 @@
                 <artifactId>polymer</artifactId>
                 <version>{{core.polymer.jsVersion}}</version>
             </dependency>
-            <dependency>
-                <groupId>org.webjars.bowergithub.webcomponents</groupId>
-                <artifactId>webcomponentsjs</artifactId>
-                <version>{{core.webcomponentsjs.jsVersion}}</version>
-            </dependency>
             <!-- Shadycss 1.8.0 is the latest bower based release for shadycss -->
             <dependency>
                 <groupId>org.webjars.bowergithub.webcomponents</groupId>


### PR DESCRIPTION
property `core.webcomponentsjs.jsVersion` was removed in https://github.com/vaadin/platform/pull/1132 from the versions file but not from the template pom.

It breaks projects, I detected the failure when running tests in multiplatform-runtime-internal/mpr-tests/cdi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1143)
<!-- Reviewable:end -->
