### PR TITLE
Add github owner prefix for vaadin-date-time-picker

### DIFF
--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -10,7 +10,10 @@ function createBower(versions, bowerTemplate) {
     let jsDeps = {};
     for (let [name, version] of Object.entries(versions)) {
         if (version.jsVersion) {
-            jsDeps[name] = `${name}#${version.jsVersion}`;
+            // Workaround for https://github.com/bower/bower/issues/2558 
+            // Registering bower package names is not supported anymore.
+            let orgPrefix = name === 'vaadin-date-time-picker' ? 'vaadin/' : '';
+            jsDeps[name] = `${orgPrefix}${name}#${version.jsVersion}`;
         }
     }
 


### PR DESCRIPTION
Registering bower package names is not supported anymore.
Bower dependencies can still be used by using the user/org name of the github repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1238)
<!-- Reviewable:end -->
