### PR TITLE
Remove flow-osgi from vaadin-bom

### DIFF
--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -92,7 +92,6 @@ This is the prerelease version of Vaadin 16 for evaluating a number of new featu
 
 ## Flow
 - The Template-in-Template feature has [some limitations](https://github.com/vaadin/flow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Atemplate-in-template+)
-- There are [some issues](https://github.com/vaadin/flow/issues/5146) in using Web Sockets as the Push channel in certain OSGi environments, but long polling works.
 - Links matching the context do not result in browser page load by default, instead they are handled with application routing. To opt-out, set the `router-ignore` attribute on the anchor element. This opt-out is needed for cases when native browser navigation is necessary, e. g., when [using `Anchor` to link a `StreamResource` download](https://github.com/vaadin/flow/issues/7623).
 
 # Migrating from Vaadin 8

--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -152,7 +152,6 @@ This lists products that have breaking changes from V14
 
 ## Flow
 - The Template-in-Template feature has [some limitations](https://github.com/vaadin/flow/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3Atemplate-in-template+)
-- There are [some issues](https://github.com/vaadin/flow/issues/5146) in using Web Sockets as the Push channel in certain OSGi environments, but long polling works.
 - Links matching the context do not result in browser page load by default, instead they are handled with application routing. To opt-out, set the `router-ignore` attribute on the anchor element. This opt-out is needed for cases when native browser navigation is necessary, e. g., when [using `Anchor` to link a `StreamResource` download](https://github.com/vaadin/flow/issues/7623).
 
 ## OSGi support

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -46,11 +46,6 @@
                 <artifactId>vaadin-cdi</artifactId>
                 <version>${flow.cdi.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-osgi</artifactId>
-                <version>${flow.version}</version>
-            </dependency>
 
             <!-- SLF4J -->
             <dependency>


### PR DESCRIPTION
Also, remove known issues of OSGi from release notes
There is no `flow-osgi` 3.0 or higher at the moment. It should have been removed from Vaadin 15 too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1249)
<!-- Reviewable:end -->
