### PR TITLE
Downgrade CustomFieldFlow to 3.1.0 in V14.3

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -133,7 +133,7 @@
         },
         "vaadin-custom-field": {
             "component": true,
-            "javaVersion": "4.1.0",
+            "javaVersion": "3.1.0",
             "jsVersion": "1.1.0",
             "npmName": "@vaadin/vaadin-custom-field"
         },


### PR DESCRIPTION
CustomFieldFlow was bumped to 4.1.0, but that version is for Flow 3.1 and lacks the `@HtmlImport` annotation.

Fixes https://github.com/vaadin/vaadin-custom-field-flow/issues/75

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1446)
<!-- Reviewable:end -->
