### PR TITLE
re-factor: refactor bom generator

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,11 +7,16 @@ For running the project, you need to execute the following script before any mav
 scripts/generateBoms.sh
 ```
 
-Probably want to make platform depend on other vaadin products snapshots like Flow, then add the following flag to the script
-```
-scripts/generateBoms.sh --useSnapshots
-```
+## Release process
 
+For releasing a new platform from CI servers the workflow should be:
+ 1. set the version to release in pom.xml file by running `mvn versions:set -DnewVersion=n.n.n`
+ 2. generate and update other pom.xml files by running `./scripts/generateBoms.sh` script.
+ 3. package  `mvn package -Pjavadocs,!bower-it,!npm-it -DskipTests`
+ 4. deploy `mvn deploy -Pproduction,release,javadocs,!bower-it,!npm-it,flatten-pom -DskipTests -DshrinkWrap`
+ 5. generate release notes `node scripts/generator/generate.js --platform=n.n.n --versions=versions.json`
+
+NOTE: that deploy needs to correctly set the credentials and target maven repo
 
 ## Installing in local repo
 

--- a/scripts/generateBoms.sh
+++ b/scripts/generateBoms.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
-cd scripts/generator && npm install && cd ../../ && node scripts/generator/generate.js --platform=18.0-SNAPSHOT --versions=versions.json "$@"
+
+# use platform version  from the root pom.xml
+version=`mvn -N help:evaluate -Dexpression=project.version -q -DforceStdout`
+# if platform version is a SNAPSHOT, use SNAPSHOTS for other dependencies
+expr "$version" : '[0-9]*.[0-9]*-SNAPSHOT' >/dev/null && snapshot=--useSnapshots
+
+# install npm deps needed for the generator node script
+[ ! -d scripts/generator/node_modules ] && (cd scripts/generator && npm install)
+
+# run the generator
+cmd="node scripts/generator/generate.js --platform=$version --versions=versions.json $snapshot"
+echo Running: "$cmd"
+$cmd || exit 1
+
+# copy generated poms to the final place
 mkdir -p vaadin-bom
 cp scripts/generator/results/vaadin-bom.xml vaadin-bom/pom.xml
 mkdir -p vaadin-spring-bom

--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -126,7 +126,9 @@ function getComponentReleaseNote(version){
    version = version.replace("-",".");
    const fullNote = requestGH(`https://api.github.com/repos/vaadin/vaadin-flow-components/releases/tags/${version}`);
    const fullNoteBody = fullNote.body;
-
+   if (!fullNoteBody) {
+       return '';
+   }
    let result = fullNoteBody.substring(
    fullNoteBody.lastIndexOf("### Changes in Components") + "### Changes in Components".length,
    fullNoteBody.lastIndexOf("###"));

--- a/versions.json
+++ b/versions.json
@@ -89,25 +89,25 @@
         },
         "vaadin-accordion": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.2.0",
             "npmName": "@vaadin/vaadin-accordion"
         },
         "vaadin-app-layout": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.2.0",
             "npmName": "@vaadin/vaadin-app-layout"
         },
         "vaadin-avatar": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.0.1",
             "npmName": "@vaadin/vaadin-avatar"
         },
         "vaadin-button": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.4.0",
             "npmName": "@vaadin/vaadin-button"
         },
@@ -117,19 +117,19 @@
                 "Checkbox",
                 "Checkbox Group"
             ],
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.5.0",
             "npmName": "@vaadin/vaadin-checkbox"
         },
         "vaadin-combo-box": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "5.4.3",
             "npmName": "@vaadin/vaadin-combo-box"
         },
         "vaadin-context-menu": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "4.5.0",
             "npmName": "@vaadin/vaadin-context-menu"
         },
@@ -139,25 +139,25 @@
         },
         "vaadin-custom-field": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.3.0",
             "npmName": "@vaadin/vaadin-custom-field"
         },
         "vaadin-date-picker": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "4.4.1",
             "npmName": "@vaadin/vaadin-date-picker"
         },
         "vaadin-date-time-picker": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.4.0",
             "npmName": "@vaadin/vaadin-date-time-picker"
         },
         "vaadin-details": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.2.0",
             "npmName": "@vaadin/vaadin-details"
         },
@@ -167,7 +167,7 @@
         },
         "vaadin-dialog": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.5.2",
             "npmName": "@vaadin/vaadin-dialog"
         },
@@ -177,7 +177,7 @@
         },
         "vaadin-form-layout": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.3.0",
             "npmName": "@vaadin/vaadin-form-layout"
         },
@@ -188,13 +188,13 @@
                 "Tree Grid",
                 "Grid Context Menu"
             ],
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "5.7.6",
             "npmName": "@vaadin/vaadin-grid"
         },
         "vaadin-icons": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "4.3.1",
             "npmName": "@vaadin/vaadin-icons"
         },
@@ -205,7 +205,7 @@
         },
         "vaadin-list-box": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.4.0",
             "npmName": "@vaadin/vaadin-list-box"
         },
@@ -215,7 +215,7 @@
         },
         "vaadin-login": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.2.0",
             "npmName": "@vaadin/vaadin-login"
         },
@@ -231,13 +231,13 @@
         },
         "vaadin-menu-bar": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.2.0",
             "npmName": "@vaadin/vaadin-menu-bar"
         },
         "vaadin-notification": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.6.0",
             "npmName": "@vaadin/vaadin-notification"
         },
@@ -248,7 +248,7 @@
                 "Vertical Layout",
                 "Flex Layout"
             ],
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.4.0",
             "npmName": "@vaadin/vaadin-ordered-layout"
         },
@@ -259,7 +259,7 @@
         },
         "vaadin-progress-bar": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.3.0",
             "npmName": "@vaadin/vaadin-progress-bar"
         },
@@ -269,7 +269,7 @@
                 "Radio Button",
                 "Radio Button Group"
             ],
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.5.1",
             "npmName": "@vaadin/vaadin-radio-button"
         },
@@ -280,19 +280,19 @@
         },
         "vaadin-select": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.4.0",
             "npmName": "@vaadin/vaadin-select"
         },
         "vaadin-split-layout": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "4.3.0",
             "npmName": "@vaadin/vaadin-split-layout"
         },
         "vaadin-tabs": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "3.2.0",
             "npmName": "@vaadin/vaadin-tabs"
         },
@@ -307,7 +307,7 @@
                 "Integer Field",
                 "Number Field"
             ],
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.8.1",
             "npmName": "@vaadin/vaadin-text-field"
         },
@@ -318,13 +318,13 @@
         },
         "vaadin-time-picker": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.4.0",
             "npmName": "@vaadin/vaadin-time-picker"
         },
         "vaadin-upload": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "4.4.0",
             "npmName": "@vaadin/vaadin-upload"
         },
@@ -340,28 +340,28 @@
         },
         "vaadin-board": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.2.0",
             "npmName": "@vaadin/vaadin-board",
             "pro": true
         },
         "vaadin-charts": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "7.0.0",
             "npmName": "@vaadin/vaadin-charts",
             "pro": true
         },
         "vaadin-confirm-dialog": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.3.0",
             "npmName": "@vaadin/vaadin-confirm-dialog",
             "pro": true
         },
         "vaadin-cookie-consent": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.2.0",
             "npmName": "@vaadin/vaadin-cookie-consent",
             "pro": true
@@ -372,7 +372,7 @@
         },
         "vaadin-crud": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.3.0",
             "npmName": "@vaadin/vaadin-crud",
             "pro": true
@@ -382,7 +382,7 @@
         },
         "vaadin-grid-pro": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "2.2.2",
             "npmName": "@vaadin/vaadin-grid-pro",
             "pro": true
@@ -393,7 +393,7 @@
         },
         "vaadin-rich-text-editor": {
             "component": true,
-            "javaVersion": "18.0.0.beta1",
+            "javaVersion": "{{version}}",
             "jsVersion": "1.3.0",
             "npmName": "@vaadin/vaadin-rich-text-editor",
             "pro": true


### PR DESCRIPTION
The idea behind this refactoring is to change the order in CI builds:
- first the version is set in `pom.xml` file by running `mvn versions:set -DnewVersion=n.n.n`
- second poms are generated with the version specified above by running `./scripts/generateBoms.sh`

No need to maintain version numbers of platform and flow components in versions.json, as well as in generator script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/platform/1629)
<!-- Reviewable:end -->
