### PR TITLE
Bump Spring addon for v18

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -7,7 +7,7 @@
             "javaVersion": "12.0.1"
         },
         "flow-spring": {
-            "javaVersion": "14.0.1"
+            "javaVersion": "15.0.0.rc1"
         },
         "gradle": {
             "javaVersion": "1.2"


### PR DESCRIPTION
15.0.0.rc1 is basically the same as the next 14.0 release, but version is bumped to help maintenance.