### PR TITLE
Fix components release notes markdown [skip ci]

### DIFF
--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -90,7 +90,7 @@ Projects marked as **(Pro)** are available for users with [Pro](https://vaadin.c
   
 ### Components
 #### Vaadin flow components
-All listed components' Java integration follow the Vaadin version [{{platform}})}(https://github.com/vaadin/vaadin-flow-components/releases/tag/{{platform}})
+All listed components' Java integration follow the Vaadin version [{{platform}}](https://github.com/vaadin/vaadin-flow-components/releases/tag/{{platform}})
 #### Vaadin Web Components
 {{components}}
 


### PR DESCRIPTION
Currently it does not render link properly:

```
[18.0.1)}(https://github.com/vaadin/vaadin-flow-components/releases/tag/18.0.1)
```