### PR TITLE
chore: add fusion-endpoint to vaadin-core

### DIFF
--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -54,6 +54,11 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>fusion-endpoint</artifactId>
+                <version>${flow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-lit-template</artifactId>
                 <version>${flow.version}</version>
             </dependency>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>fusion-endpoint</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-lit-template</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Add fusion-endpoint dependency to endpoint testing modules.
https://github.com/vaadin/flow/pull/9499 needs to be merged first.