### PR TITLE
Update ci-sauce version

### DIFF
--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -194,7 +194,7 @@
                     <dependency>
                         <groupId>com.saucelabs</groupId>
                         <artifactId>ci-sauce</artifactId>
-                        <version>1.138</version>
+                        <version>1.151</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
older version uses outdated sauce-connect which cause validation fail