### PR TITLE
Add smoke test for CollaborationAvatarGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ vaadin-platform-test/webpack.generated.js
 
 vaadin-bom/pom.xml
 vaadin-spring-bom/pom.xml
-collaborationEngineDataDir

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ vaadin-platform-test/webpack.generated.js
 
 vaadin-bom/pom.xml
 vaadin-spring-bom/pom.xml
+collaborationEngineDataDir

--- a/platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -149,7 +149,7 @@
             <version>2.8.0</version>
         </dependency>
 
-        <!-- Those dependencies are need for OSGi container where this bundle 
+        <!-- Those dependencies are need for OSGi container where this bundle
             will be deployed. -->
 
         <dependency>
@@ -229,7 +229,7 @@
             <id>production</id>
             <build>
                 <plugins>
-                    <!-- This dynamically calculates all the things we need 
+                    <!-- This dynamically calculates all the things we need
                         to run our code. -->
                     <plugin>
                         <groupId>biz.aQute.bnd</groupId>
@@ -324,7 +324,7 @@
                             </dependency>
                         </dependencies>
                         <executions>
-                            <!-- Start Sauce Connect prior to running the 
+                            <!-- Start Sauce Connect prior to running the
                                 integration tests -->
                             <execution>
                                 <id>start-sauceconnect</id>
@@ -333,7 +333,7 @@
                                     <goal>start-sauceconnect</goal>
                                 </goals>
                             </execution>
-                            <!-- Stop the Sauce Connect process after the 
+                            <!-- Stop the Sauce Connect process after the
                                 integration tests have finished -->
                             <execution>
                                 <id>stop-sauceconnect</id>
@@ -349,8 +349,6 @@
                             <options>${sauce.options}</options>
                         </configuration>
                     </plugin>
-
-
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
@@ -367,6 +365,7 @@
                                     <asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
                                     <workingDirectory>${project.build.directory}</workingDirectory>
                                     <arguments>
+                                        <argument>-Dvaadin.ce.dataDir=${project.build.directory}</argument>
                                         <argument>-jar</argument>
                                         <argument>app.jar</argument>
                                     </arguments>
@@ -411,10 +410,24 @@
                             <trimStackTrace>false</trimStackTrace>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                            <version>3.0.0</version>
+                            <executions>
+                                <execution>
+                                    <phase>compile</phase>
+                                    <configuration>
+                                        <target><echo file="${project.build.directory}/ce-license.json">${ce.license}</echo></target>
+                                    </configuration>
+                                    <goals>
+                                        <goal>run</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                      </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
 
 </project>
-

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -235,6 +235,33 @@
 
     <profiles>
         <profile>
+            <id></id>
+            <activation>
+                <property>
+                    <name>ce.license</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                      <artifactId>maven-antrun-plugin</artifactId>
+                      <version>3.0.0</version>
+                      <executions>
+                        <execution>
+                          <phase>compile</phase>
+                          <configuration>
+                            <target><echo file="collaborationEngineDataDir/ce-license.json">${ce.license}</echo></target>
+                          </configuration>
+                          <goals>
+                            <goal>run</goal>
+                          </goals>
+                        </execution>
+                      </executions>
+                    </plugin>
+                  </plugins>                
+            </build>
+        </profile>
+        <profile>
             <id>ITs</id>
             <activation>
                 <property>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -236,7 +236,7 @@
                   <execution>
                     <phase>compile</phase>
                     <configuration>
-                      <target><echo file="collaborationEngineDataDir/ce-license.json">${ce.license}</echo></target>
+                      <target><echo file="${project.build.directory}/ce-license.json">${ce.license}</echo></target>
                     </configuration>
                     <goals>
                       <goal>run</goal>
@@ -306,7 +306,7 @@
                             <systemProperties>
                                 <systemProperty>
                                     <name>vaadin.ce.dataDir</name>
-                                    <value>${project.basedir}/collaborationEngineDataDir</value>
+                                    <value>${project.build.directory}</value>
                                 </systemProperty>
                             </systemProperties>
                         </configuration>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -289,6 +289,12 @@
                             <stopWait>5</stopWait>
                             <stopKey>foo</stopKey>
                             <scanIntervalSeconds>1</scanIntervalSeconds>
+                            <systemProperties>
+                                <systemProperty>
+                                    <name>vaadin.ce.dataDir</name>
+                                    <value>${project.basedir}/collaborationEngineDataDir</value>
+                                </systemProperty>
+                            </systemProperties>
                         </configuration>
                         <executions>
                             <execution>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -229,38 +229,25 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                  <execution>
+                    <phase>compile</phase>
+                    <configuration>
+                      <target><echo file="collaborationEngineDataDir/ce-license.json">${ce.license}</echo></target>
+                    </configuration>
+                    <goals>
+                      <goal>run</goal>
+                    </goals>
+                  </execution>
+                </executions>
+              </plugin>
         </plugins>
     </build>
 
     <profiles>
-        <profile>
-            <id></id>
-            <activation>
-                <property>
-                    <name>ce.license</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                      <artifactId>maven-antrun-plugin</artifactId>
-                      <version>3.0.0</version>
-                      <executions>
-                        <execution>
-                          <phase>compile</phase>
-                          <configuration>
-                            <target><echo file="collaborationEngineDataDir/ce-license.json">${ce.license}</echo></target>
-                          </configuration>
-                          <goals>
-                            <goal>run</goal>
-                          </goals>
-                        </execution>
-                      </executions>
-                    </plugin>
-                  </plugins>                
-            </build>
-        </profile>
         <profile>
             <id>ITs</id>
             <activation>

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.IOUtils;
-
+import com.vaadin.collaborationengine.CollaborationAvatarGroup;
+import com.vaadin.collaborationengine.UserInfo;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.accordion.Accordion;
@@ -140,6 +140,8 @@ import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.internal.MessageDigestUtil;
 import com.vaadin.flow.router.Route;
+
+import org.apache.commons.io.IOUtils;
 
 @Route("")
 public class ComponentsView extends AppLayout {
@@ -552,9 +554,15 @@ public class ComponentsView extends AppLayout {
 
         AccordionPanel accordionPanel = new AccordionPanel("AccordionPanel", new Span("Content"));
 
+        // Test for avatar components
         Avatar avatar = new Avatar("Donald");
         AvatarGroup avatarGroup = new AvatarGroup(new AvatarGroupItem("Pluto"), new AvatarGroupItem("Mickey"));
 
+        // Tests for collaboration engine
+        CollaborationAvatarGroup collaborationAvatarGroup =
+                new CollaborationAvatarGroup(new UserInfo("foo", "foo"), "topic-id");
+        CollaborationAvatarGroup collaborationAvatarGroup2 =
+                new CollaborationAvatarGroup(new UserInfo("bar", "bar"), "topic-id");
 
         // These components are flow internal classes, these lines is to make pass the ComponentUsageTest
         JavaScriptBootstrapUI javaScriptBootstrapUI;
@@ -598,6 +606,7 @@ public class ComponentsView extends AppLayout {
         components.add(menuBar);
         components.add(avatar);
         components.add(avatarGroup);
+        components.add(collaborationAvatarGroup, collaborationAvatarGroup2);
         components.add(main);
 
         layouts.add(formLayout);

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -27,6 +27,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.vaadin.collaborationengine.CollaborationAvatarGroup;
+import com.vaadin.collaborationengine.CollaborationEngine;
+import com.vaadin.collaborationengine.CollaborationEngineConfiguration;
 import com.vaadin.collaborationengine.UserInfo;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlComponent;
@@ -140,11 +142,19 @@ import com.vaadin.flow.data.provider.hierarchy.HierarchicalQuery;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.internal.MessageDigestUtil;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
 
 import org.apache.commons.io.IOUtils;
 
 @Route("")
 public class ComponentsView extends AppLayout {
+
+    static {
+        CollaborationEngine.configure(VaadinService.getCurrent(),
+                new CollaborationEngineConfiguration(e -> {
+                    // no-op
+                }));
+    }
 
     private static final long serialVersionUID = 1L;
 

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -571,8 +571,10 @@ public class ComponentsView extends AppLayout {
         // Tests for collaboration engine
         CollaborationAvatarGroup collaborationAvatarGroup =
                 new CollaborationAvatarGroup(new UserInfo("foo", "foo"), "topic-id");
+        collaborationAvatarGroup.setId("collab-avatar-group-1");
         CollaborationAvatarGroup collaborationAvatarGroup2 =
                 new CollaborationAvatarGroup(new UserInfo("bar", "bar"), "topic-id");
+        collaborationAvatarGroup2.setId("collab-avatar-group-2");
 
         // These components are flow internal classes, these lines is to make pass the ComponentUsageTest
         JavaScriptBootstrapUI javaScriptBootstrapUI;

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -15,12 +15,11 @@
  */
 package com.vaadin.platform.test;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -533,15 +532,13 @@ public class ChromeComponentsIT extends AbstractPlatformTest {
 
     @Test
     public void collaborationAvatarGroupIsRendered() {
-        AvatarGroupElement group = $(AvatarGroupElement.class).get(1);
-        assertElementRendered(group);
-        assertEquals("foo", group.getAvatarElement(0).getPropertyString("name"));
-        assertEquals("bar", group.getAvatarElement(1).getPropertyString("name"));
-
-        group = $(AvatarGroupElement.class).get(2);
-        assertElementRendered(group);
-        assertEquals("bar", group.getAvatarElement(0).getPropertyString("name"));
-        assertEquals("foo", group.getAvatarElement(1).getPropertyString("name"));
+        AvatarGroupElement group1 = $(AvatarGroupElement.class).id("collab-avatar-group-1");
+        AvatarGroupElement group2 = $(AvatarGroupElement.class).id("collab-avatar-group-2");
+        for (AvatarGroupElement group : Arrays.asList(group1, group2)) {
+            assertElementRendered(group);
+            Assert.assertEquals("bar", group.getAvatarElement(0).getPropertyString("name"));
+            Assert.assertEquals("foo", group.getAvatarElement(1).getPropertyString("name"));
+        }
     }
 
     @Test

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.platform.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -25,20 +27,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.internal.WrapsElement;
-import org.openqa.selenium.logging.LogEntry;
-import org.openqa.selenium.logging.LogType;
-import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.slf4j.LoggerFactory;
-
+import com.vaadin.flow.component.avatar.testbench.AvatarGroupElement;
 import com.vaadin.flow.component.button.testbench.ButtonElement;
 import com.vaadin.flow.component.checkbox.testbench.CheckboxElement;
 import com.vaadin.flow.component.combobox.testbench.ComboBoxElement;
@@ -65,6 +54,20 @@ import com.vaadin.flow.component.upload.testbench.UploadElement;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.annotations.BrowserConfiguration;
 import com.vaadin.testbench.parallel.Browser;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.slf4j.LoggerFactory;
 
 public class ChromeComponentsIT extends AbstractPlatformTest {
 
@@ -526,6 +529,19 @@ public class ChromeComponentsIT extends AbstractPlatformTest {
                 items.get(0));
 
         assertLog("Context menu Item 0 is clicked");
+    }
+
+    @Test
+    public void collaborationAvatarGroupIsRendered() {
+        AvatarGroupElement group = $(AvatarGroupElement.class).get(1);
+        assertElementRendered(group);
+        assertEquals("foo", group.getAvatarElement(0).getPropertyString("name"));
+        assertEquals("bar", group.getAvatarElement(1).getPropertyString("name"));
+
+        group = $(AvatarGroupElement.class).get(2);
+        assertElementRendered(group);
+        assertEquals("bar", group.getAvatarElement(0).getPropertyString("name"));
+        assertEquals("foo", group.getAvatarElement(1).getPropertyString("name"));
     }
 
     @Test


### PR DESCRIPTION
By attaching two groups with distinct users, and asserting
that two avatars are visible, it ensures that Collaboration
Engine is working and synchronizing the avatars.