### PR TITLE
chore:add old snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>vaadin-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
     </repositories>
     <pluginRepositories>
         <!-- Main Maven repository -->
@@ -72,6 +77,11 @@
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>vaadin-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
some old dependencies are not existing in the new snapshot repo, for example, vaadin-testbench-bom, so add the old one back