### PR TITLE
chore: add vaadin-dev-server dependency

### DIFF
--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -59,6 +59,11 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-dev-server</artifactId>
+                <version>${flow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-lit-template</artifactId>
                 <version>${flow.version}</version>
             </dependency>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -44,6 +44,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-lit-template</artifactId>
         </dependency>
         <dependency>

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "flow": {
-            "javaVersion": "8.0.0.alpha3"
+            "javaVersion": "8.0-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "12.0.1"


### PR DESCRIPTION
The dev server and live reload functionality has recently been
factored out of flow-server (so that it can be excluded in 
production mode). Add the dependency to the new module
(vaadin-dev-server) to vaadin-core to not break existing projects.