### PR TITLE
chore: java-17 is still unsupported in gradle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <profile>
             <id>gradle</id>
             <activation>
-                <jdk>(,17]</jdk>
+                <jdk>(,16]</jdk>
             </activation>
             <modules>
                 <module>vaadin-gradle-plugin</module>


### PR DESCRIPTION
Changes in https://github.com/vaadin/platform/pull/2181 for limiting java version do not work