### PR TITLE
test: set openPageNoClientSideError to false, to avoid Push errors in client

### DIFF
--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -154,10 +154,10 @@ import org.apache.commons.io.IOUtils;
 public class ComponentsView extends AppLayout {
 
     static {
-        CollaborationEngine.configure(VaadinService.getCurrent(),
-                new CollaborationEngineConfiguration(e -> {
-                    // no-op
-                }));
+        CollaborationEngineConfiguration cfg = new CollaborationEngineConfiguration(e -> {/* NO-OP */});
+        // Deactivate Push (https://github.com/vaadin/collaboration-engine-internal/issues/615)
+        cfg.setAutomaticallyActivatePush(false);
+        CollaborationEngine.configure(VaadinService.getCurrent(), cfg);
     }
 
     private static final long serialVersionUID = 1L;

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -641,8 +641,9 @@ public class ChromeComponentsIT extends AbstractPlatformTest {
         return driver.manage().logs().get(LogType.BROWSER).getAll().stream()
                 .filter(logEntry -> logEntry.getLevel().intValue() >= level
                         .intValue())
-                // exclude some known errors
-                .filter(logEntry -> !logEntry.getMessage().matches(".*(favicon.ico|ws://).*"))
+                // exclude the favicon error
+                .filter(logEntry -> !logEntry.getMessage()
+                        .contains("favicon.ico"))
                 .collect(Collectors.toList());
     }
 

--- a/versions.json
+++ b/versions.json
@@ -376,7 +376,7 @@
             "pro": true
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "3.2.0.alpha1"
+            "javaVersion": "3.2.0.alpha2"
         },
         "vaadin-confirm-dialog": {
             "component": true,

--- a/versions.json
+++ b/versions.json
@@ -376,7 +376,7 @@
             "pro": true
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "3.2-SNAPSHOT"
+            "javaVersion": "3.2.0.alpha1"
         },
         "vaadin-confirm-dialog": {
             "component": true,

--- a/versions.json
+++ b/versions.json
@@ -376,7 +376,7 @@
             "pro": true
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "3.2.0.alpha1"
+            "javaVersion": "3.2-SNAPSHOT"
         },
         "vaadin-confirm-dialog": {
             "component": true,


### PR DESCRIPTION
Disable PUSH in CE in order to avoid client side Push errors that breaks `ChromeComponentsIT.openPageNoClientSideError` test checking for client-side errors, and OSGi tests in `platform-servlet-containers-tests/bnd-tools-test`.
https://github.com/vaadin/collaboration-engine-internal/issues/615

This code will not compile until CE releases `3.2.0.alpha2` and platform depends on it