### PR TITLE
fix: remove vaadin-bom from maven plugin build

### DIFF
--- a/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
@@ -22,17 +22,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
The used dependency versions for Maven plugin should be the same as what are used in the flow build.
There was an issue now that the plugin is getting an outdated commons-io version from the components.

Follow up step is to fix/pin the commons version for `vaadin-bom` to a newer one.