### PR TITLE
Chore: move Jandex module to a separate profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,6 @@
         <module>vaadin-testbench</module>
         <module>vaadin-spring-boot-starter</module>
         <module>vaadin-platform-javadoc</module>
-        <module>vaadin-jandex</module>
-        <module>vaadin-core-jandex</module>
     </modules>
 
     <profiles>
@@ -48,6 +46,13 @@
             </activation>
             <modules>
                 <module>vaadin-gradle-plugin</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jandex</id>
+            <modules>
+                <module>vaadin-jandex</module>
+                <module>vaadin-core-jandex</module>
             </modules>
         </profile>
         <!-- Needed so as we can skip this module on releasing and still nexus stating works -->


### PR DESCRIPTION
move Jandex module to a profile.
when run `mvn test` or any lifecycle before `package` for platform, the build failed as Jandex module expects jar files from other modules which should be generated during package phrase.

this should fix the failure with the JDK test. 
