### PR TITLE
chore: ignore warning lines when running in a docker container [skip ci]

### DIFF
--- a/scripts/generateBoms.sh
+++ b/scripts/generateBoms.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # use platform version  from the root pom.xml
-version=`mvn -N help:evaluate -Dexpression=project.version -q -DforceStdout`
+version=`mvn -N help:evaluate -Dexpression=project.version -q -DforceStdout | grep "^[0-9]"`
 
 snapshot=$1
 


### PR DESCRIPTION
In docker containers, maven sometimes outputs an extra error which pollutes generated poms.

```
[0.001s][warning][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /sys/fs/cgroup/cpuset.
21.0-SNAPSHOT
```