### PR TITLE
chore: revert removing bytebuddy dependency

### DIFF
--- a/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -34,6 +34,11 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.11.0</version>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The dependency removed in https://github.com/vaadin/platform/pull/2247 is still needed for OSGI 