### PR TITLE
Fix: Point to start.vaadin.com

### DIFF
--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -27,7 +27,7 @@ Here are the highlighted new and improved features in this maintenance release.
 
 # Getting Started with Vaadin 14
 ## App starters
-The best way to get started with Vaadin 14 is to go to [https://vaadin.com/start](https://vaadin.com/start) and pick an app template for the technology stack you’re interested in.
+The best way to get started with Vaadin 14 is to go to [https://start.vaadin.com](https://start.vaadin.com) and pick an app template for the technology stack you’re interested in.
 
 For the full list of how to get started go to the [GitHub releases](https://github.com/vaadin/platform/releases/tag/14.6.0).
 

--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -27,7 +27,7 @@ Here are the highlighted new and improved features in this maintenance release.
 
 # Getting Started with Vaadin 14
 ## App starters
-The best way to get started with Vaadin 14 is to go to [https://start.vaadin.com](https://start.vaadin.com) and pick an app template for the technology stack you’re interested in.
+The best way to get started with Vaadin 14 is to go to [https://start.vaadin.com](https://start.vaadin.com) and configure your new application by setting up your views, entities, and styles.
 
 For the full list of how to get started go to the [GitHub releases](https://github.com/vaadin/platform/releases/tag/14.6.0).
 


### PR DESCRIPTION
start.vaadin.com (not vaadin.com/start) is the preferred way to start a new Vaadin app. 