### PR TITLE
test: forward grid.browsers parameter (14.x)

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -31,9 +31,14 @@ public class ComponentsIT extends ParallelTest {
 
     static {
         String sauceUser = System.getProperty("sauce.user");
+        String browsers = System.getProperty("grid.browser");
         if (sauceUser != null && !sauceUser.isEmpty()) {
+            if (browsers == null || browsers.isEmpty()) {
             Parameters.setGridBrowsers(System.getProperty("grid.browsers",
                     "ie11,firefox,chrome,safari-9,safari-10,safari-11,edge,edge-18"));
+            } else {
+                Parameters.setGridBrowsers(browsers);
+            }
         }
     }
 

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -34,8 +34,7 @@ public class ComponentsIT extends ParallelTest {
         String browsers = System.getProperty("grid.browsers");
         if (sauceUser != null && !sauceUser.isEmpty()) {
             if (browsers == null || browsers.isEmpty()) {
-            Parameters.setGridBrowsers(System.getProperty("grid.browsers",
-                    "ie11,firefox,chrome,safari-9,safari-10,safari-11,edge,edge-18"));
+                Parameters.setGridBrowsers("ie11,firefox,chrome,safari-9,safari-10,safari-11,edge,edge-18");
             } else {
                 Parameters.setGridBrowsers(browsers);
             }

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -31,7 +31,7 @@ public class ComponentsIT extends ParallelTest {
 
     static {
         String sauceUser = System.getProperty("sauce.user");
-        String browsers = System.getProperty("grid.browser");
+        String browsers = System.getProperty("grid.browsers");
         if (sauceUser != null && !sauceUser.isEmpty()) {
             if (browsers == null || browsers.isEmpty()) {
             Parameters.setGridBrowsers(System.getProperty("grid.browsers",


### PR DESCRIPTION
## Description
when `grid.browsers` is not set from command line, use the setting from code file.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
