### PR TITLE
chore: add jsoup dependency

### DIFF
--- a/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -220,6 +220,19 @@
         </dependency>
         <!-- End Gogo Shell -->
 
+        <!-- explicitly include transitice dependency of JSON 1.4 to be able to activate the bundle -->
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.14.1</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
after flow updated the jsoup version (https://github.com/vaadin/flow/commit/688ee59c54f79f4ec906b5b54ce20b662c155747), we need the following changes to make the OSGi test pass. 