### PR TITLE
chore:fix osgi test

### DIFF
--- a/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -227,12 +227,6 @@
             <version>3.0.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.jsoup</groupId>
-            <artifactId>jsoup</artifactId>
-            <version>1.14.1</version>
-        </dependency>
-
     </dependencies>
 
     <profiles>

--- a/vaadin-platform-servlet-containers-tests/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/pom.xml
@@ -40,6 +40,13 @@
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </pluginRepository>
     </pluginRepositories>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
fix the osgi test

add `flow-server` to the module to get all the transitive dependencies. 