### PR TITLE
Revert "chore: update versions.json in 14.7 with latest WC (#2342)"

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -189,7 +189,7 @@
                 "Grid Context Menu"
             ],
             "javaVersion": "{{version}}",
-            "jsVersion": "5.8.4",
+            "jsVersion": "5.8.3",
             "npmName": "@vaadin/vaadin-grid"
         },
         "vaadin-icons": {


### PR DESCRIPTION
the web component update PR on flow components side has been failing all the time. https://github.com/vaadin/flow-components/pull/2045

so this update should be reverted on our side 