### PR TITLE
chore: use fixed webdriver manager

### DIFF
--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>LATEST</version>
+            <version>4.4.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
the LATEST version of Web Driver Manager requires higher version of JDK (instead of JDK8)