### PR TITLE
Revert "chore: update versions.json in 14.8 with latest WC (#2402)"

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -356,7 +356,7 @@
         "vaadin-charts": {
             "component": true,
             "javaVersion": "{{version}}",
-            "jsVersion": "6.3.2",
+            "jsVersion": "6.3.1",
             "npmName": "@vaadin/vaadin-charts",
             "pro": true
         },


### PR DESCRIPTION
This reverts commit dbb6a4f48c8d111cb8c580698085193b355ce5b7.

Recent fix in Chart web component has brought in a [regression](https://vaadin.slack.com/archives/C3TGRP4HY/p1632242505221100?thread_ts=1631875262.193500&cid=C3TGRP4HY) 