### PR TITLE
Revert "chore: update versions.json in 14.7 with latest WC (#2401)"

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -356,7 +356,7 @@
         "vaadin-charts": {
             "component": true,
             "javaVersion": "{{version}}",
-            "jsVersion": "6.3.2",
+            "jsVersion": "6.3.1",
             "npmName": "@vaadin/vaadin-charts",
             "pro": true
         },


### PR DESCRIPTION
This reverts commit edc303d16a729d84b2a0caae35b41cdd03af626f.

Recent fix in Chart web component has brought in a [regression](https://vaadin.slack.com/archives/C3TGRP4HY/p1632242505221100?thread_ts=1631875262.193500&cid=C3TGRP4HY) 