### PR TITLE
chore: align kotlin dependency versions with flow

### DIFF
--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '0.11.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
     id 'org.jetbrains.dokka' version '1.4.32'
 }
 
@@ -34,15 +34,13 @@ targetCompatibility = 1.8
 
 sourceSets {
     functionalTest {
-        kotlin {
-            srcDir file('src/functionalTest/kotlin')
-        }
-        resources {
-            srcDir file('src/functionalTest/resources')
-        }
-        compileClasspath += sourceSets.main.output + configurations.testRuntime
-        runtimeClasspath += output + compileClasspath
+       compileClasspath += sourceSets.main.output
+       runtimeClasspath += sourceSets.main.output
     }
+}
+
+configurations {
+    functionalTestImplementation.extendsFrom testImplementation
 }
 
 task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
@@ -65,10 +63,10 @@ repositories {
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.31")
-    compile("com.vaadin:flow-plugin-base:${pom.properties.getAt('flow.version')}")
-    testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test:1.4.31")
+    implementation('org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31')
+    implementation("com.vaadin:flow-plugin-base:${pom.properties.getAt('flow.version')}")
+    testImplementation("junit:junit:4.12")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.5.31")
 }
 
 idea {


### PR DESCRIPTION
[fix JDK test failure](https://bender.vaadin.com/viewType.html?buildTypeId=JDKs).  same fix has been applied to flow (verified.)

chore: align kotlin dependency versions with flow 
also pick the change from flow vaadin/flow@1a057da