### PR TITLE
deploy gradle plugin for portal in maven repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,10 @@ scripts/generator/yarn-error.log
 **/tsconfig.json
 **/types.d.ts
 **/.npmrc
+bin/
 
 vaadin-bom/pom.xml
 vaadin-spring-bom/pom.xml
 vaadin-maven-plugin/pom.xml
 vaadin-gradle-plugin/pom.xml
+vaadin-gradle-plugin/pom*xml

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
             </activation>
             <modules>
                 <module>vaadin-gradle-plugin</module>
+                <module>vaadin-gradle-plugin/pom-portal.xml</module>
             </modules>
         </profile>
         <profile>

--- a/scripts/generateBoms.sh
+++ b/scripts/generateBoms.sh
@@ -21,4 +21,5 @@ cp scripts/generator/results/vaadin-spring-bom.xml vaadin-spring-bom/pom.xml
 
 cp scripts/generator/results/vaadin-maven-plugin-pom.xml vaadin-maven-plugin/pom.xml
 cp scripts/generator/results/vaadin-gradle-plugin-pom.xml vaadin-gradle-plugin/pom.xml
+cp scripts/generator/results/vaadin-gradle-plugin-portal-pom.xml vaadin-gradle-plugin/pom-portal.xml
 cp scripts/generator/results/vaadin-platform-servlet-containers-tests-pom.xml vaadin-platform-servlet-containers-tests/pom.xml

--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -61,6 +61,10 @@ const mavenPluginResultPomFileName = getResultsFilePath('vaadin-maven-plugin-pom
 const gradlePluginTemplatePomFileName = getTemplateFilePath('template-vaadin-gradle-plugin-pom.xml');
 const gradlePluginResultPomFileName = getResultsFilePath('vaadin-gradle-plugin-pom.xml');
 
+const gradlePortalPluginTemplatePomFileName = getTemplateFilePath('template-vaadin-gradle-plugin-portal-pom.xml');
+const gradlePortalPluginResultPomFileName = getResultsFilePath('vaadin-gradle-plugin-portal-pom.xml');
+
+
 const servletContainersTestsPomFileName = getTemplateFilePath('template-servlet-containers-tests-pom.xml');
 const servletContainersTestsResultPomFileName = getResultsFilePath('vaadin-platform-servlet-containers-tests-pom.xml');
 
@@ -82,6 +86,7 @@ writer.writePackageJson(versions.core, coreShrinkwrapTemplateFileName, coreShrin
 
 writer.writeProperty(versions, "flow", mavenPluginTemplatePomFileName, mavenPluginResultPomFileName);
 writer.writeProperty(versions, "flow", gradlePluginTemplatePomFileName, gradlePluginResultPomFileName);
+writer.writeProperty(versions, "flow", gradlePortalPluginTemplatePomFileName, gradlePortalPluginResultPomFileName);
 writer.writeProperty(versions, "flow", servletContainersTestsPomFileName, servletContainersTestsResultPomFileName);
 
 

--- a/scripts/generator/templates/template-vaadin-gradle-plugin-portal-pom.xml
+++ b/scripts/generator/templates/template-vaadin-gradle-plugin-portal-pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.vaadin</groupId>
+  <artifactId>com.vaadin.gradle.plugin</artifactId>
+  <version>{{platform}}</version>
+  <packaging>pom</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-gradle-plugin</artifactId>
+      <version>{{platform}}</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
Because plugin deployed to the Gradle portal has a different artifactId to the actual plugin we need to publish also in maven repos so as we can use prereleases and snapshots.

Related to: https://github.com/vaadin/base-starter-flow-quarkus/issues/12 

