### PR TITLE
chore: align flow module versions in 14.8

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "flow": {
-            "javaVersion": "2.7.0"
+            "javaVersion": "2.7.2"
         },
         "flow-cdi": {
             "javaVersion": "11.3.0"
@@ -74,10 +74,10 @@
             "npmVersion": "3.0.1"
         },
         "mpr-v7": {
-            "javaVersion": "2.2.4"
+            "javaVersion": "2.2.5"
         },
         "mpr-v8": {
-            "javaVersion": "2.2.4"
+            "javaVersion": "2.2.5"
         },
         "polymer": {
             "jsVersion": "2.7.0"


### PR DESCRIPTION
as 14.8 is sharing the same flow minor now, pick the updates in 14.7 to this branch

