### PR TITLE
chore: update Safari and iOS versions for V22

### DIFF
--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -124,7 +124,7 @@ Development is supported with the following operating systems:
 
 ## Mobile Browsers
 The following built-in browsers in the following mobile operating systems:
-- Safari starting from iOS 13
+- Safari starting from 14.1 (iOS 14.5)
 - Google Chrome evergreen on Android (requiring Android 4.4 or newer)
 
 ## Development environments


### PR DESCRIPTION
## Description

In Vaadin 22 we use some APIs like [gap property for Flexbox](https://caniuse.com/flexbox-gap) that require Safari 14.1 / iOS 14.5+

## Type of change

- Release notes update