### PR TITLE
chore: add back the missing bnd file

### DIFF
--- a/vaadin-platform-test/bnd.bnd
+++ b/vaadin-platform-test/bnd.bnd
@@ -1,0 +1,9 @@
+-fixupmessages:
+Bundle-SymbolicName: ${project.groupId}.platform-test
+Bundle-Name: Vaadin Platform Server Tests
+Bundle-Version: ${osgi.bundle.version}
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
+Import-Package: *
+Export-Package: com.vaadin.platform.test*;-noimport:=true
+Vaadin-OSGi-Extender: true


### PR DESCRIPTION
fix master branch snapshot failure with OSGi