### PR TITLE
chore: add workaround for dependency license

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
@@ -53,6 +53,13 @@ public class LicenseCheckTest {
         whitelist.add("http://www.apache.org/licenses/LICENSE-2.0.html");
         whitelist.add("https://www.apache.org/licenses/LICENSE-2.0.txt");
         whitelist.add("https://spdx.org/licenses/Apache-2.0#licenseText");
+         /*
+         * License names used by some projects that define their license to be
+         * something like to http://projectdomain.com/license, for which the
+         * contents might change without notice
+         * for example: the vaadin__vaadin-mobile-drag-drop::1.0.1
+         */
+        whitelist.add("Apache-2.0");
 
         // BSD
         whitelist.add("http://www.opensource.org/licenses/bsd-license.php");


### PR DESCRIPTION
License names used by some projects that define their license to be something like to http://projectdomain.com/license, for which the contents might change without notice
for example: the vaadin__vaadin-mobile-drag-drop::1.0.1

this workaround has been used in flow project https://github.com/vaadin/flow/blob/9c232b8a0d58c29ac76cf9f04f520033c0dbfa6e/build-tools/src/test/java/com/vaadin/LicenseCheckTest.java#L62

checking the generated license.xml after `maven license:download-licenses`
with 1.0.0 version 
```
<dependency>
      <groupId>org.webjars.npm</groupId>
      <artifactId>vaadin__vaadin-mobile-drag-drop</artifactId>
      <version>1.0.0</version>
      <licenses>
        <license>
          <name>Apache-2.0</name>
          <url>https://spdx.org/licenses/Apache-2.0#licenseText</url>
          <distribution>repo</distribution>
          <file>apache-2.0 - apache-2.0.html</file>
        </license>
      </licenses>
    </dependency>
```

and with 1.0.1 version

```
<dependency>
      <groupId>org.webjars.npm</groupId>
      <artifactId>vaadin__vaadin-mobile-drag-drop</artifactId>
      <version>1.0.1</version>
      <licenses>
        <license>
          <name>Apache-2.0</name>
          <distribution>repo</distribution>
        </license>
      </licenses>
    </dependency>
```