### PR TITLE
chore: add feature request template [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Vaadin discord chat
     url: https://discord.gg/vaadin
     about: You can ask question for fast responds here.
-  - name: Report a security vulnerability
-    url: https://github.com/vaadin/platform/security/policy
-    about: Please review our security policy for more details

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: "\U0001F680 Feature Request"
+description: Asking for a new feature/API in vaadin
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe your motivation
+      description: A concise description of why you are proposing a change. For example, you would like a new feature to solve a use-case, or you want an existing feature changed because it is difficult to use.
+      placeholder: describe the current issue with existing feature/API
+    validations:
+      required: true
+  - type: textarea
+    id: expected-solution
+    attributes:
+      label: Describe the solution you'd like
+      description: Provide a clear and concise description of what you want to happen.
+      placeholder: expected solution
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Provide information about other solutions you've tried or researched.
+      placeholder: alternatives
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Is there anything else you can add about the proposal?
+      placeholder: additional context
+      


### PR DESCRIPTION
remove the duplicated `security vulnerability`
feature request template content has been used in [flow-components](https://github.com/vaadin/flow-components/issues/new?assignees=&labels=i%3A+needs+triage&template=feature_request.md&title=)