### PR TITLE
chore: refactor hilla artifacts

### DIFF
--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>hilla-spring-boot-starter</artifactId>
     <name>Hilla Spring Boot Starter</name>
     <description>Spring Boot Starter for Hilla applications.</description>
+    <version>1.0-SNAPSHOT</version>
 
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
@@ -44,7 +45,7 @@
                 <artifactId>vaadin-spring-bom</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>${project.version}</version>
+                <version>${parent.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.hilla</groupId>

--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>hilla-spring-boot-starter</artifactId>
     <name>Hilla Spring Boot Starter</name>
     <description>Spring Boot Starter for Hilla applications.</description>
-    <version>1.0-SNAPSHOT</version>
+    <version>${hilla.version}</version>
 
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
     <name>Hilla Platform</name>
     <description>Hilla Platform</description>
-    <version>1.0-SNAPSHOT</version>
+    <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
 
     <distributionManagement>

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
     <name>Hilla Platform</name>
     <description>Hilla Platform</description>
+    <version>1.0-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <hilla.version>1.0-SNAPSHOT</hilla.version>
     </properties>
 
     <distributionManagement>

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -11,6 +11,7 @@
     <packaging>pom</packaging>
     <name>HIlla Platform (Bill of Materials)</name>
     <description>Hilla Platform (Bill of Materials)</description>
+    <version>1.0-SNAPSHOT</version>
     <url>https://hilla.dev</url>
 
     <distributionManagement>
@@ -32,12 +33,12 @@
             <dependency>
                 <groupId>dev.hilla</groupId>
                 <artifactId>hilla</artifactId>
-                <version>{{platform}}</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>dev.hilla</groupId>
                 <artifactId>hilla-spring-boot-starter</artifactId>
-                <version>{{platform}}</version>
+                <version>1.0-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -33,12 +33,12 @@
             <dependency>
                 <groupId>dev.hilla</groupId>
                 <artifactId>hilla</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.hilla</groupId>
                 <artifactId>hilla-spring-boot-starter</artifactId>
-                <version>1.0-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -11,7 +11,7 @@
     <packaging>pom</packaging>
     <name>HIlla Platform (Bill of Materials)</name>
     <description>Hilla Platform (Bill of Materials)</description>
-    <version>1.0-SNAPSHOT</version>
+    <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
 
     <distributionManagement>


### PR DESCRIPTION
as hilla bom will be released from version 1.0. extracting `hilla.version` as a property, so that we can set a version before doing a release