### PR TITLE
fix: Write correct manifest for test module

### DIFF
--- a/vaadin-platform-test/bnd.bnd
+++ b/vaadin-platform-test/bnd.bnd
@@ -7,3 +7,4 @@ Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
 Import-Package: *
 Export-Package: com.vaadin.platform.test*;-noimport:=true
 Vaadin-OSGi-Extender: true
+Require-Capability: osgi.extender;filter:="(&(osgi.extender=osgi.component)(version>=1.4.0)(!(version>=2.0.0)))",osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"


### PR DESCRIPTION
bnd plugin 3.5.0 does not recognize JavaSE-11 as a valid version so it writes "UNKNOWN" by default
bnd plugin 6.0.0 writes the correct Java version but adds lots of import packages which should not be there
