### PR TITLE
chore: provided dependencies for javadoc generation under java 11 [skip ci]

### DIFF
--- a/vaadin-platform-javadoc/pom.xml
+++ b/vaadin-platform-javadoc/pom.xml
@@ -47,10 +47,52 @@
     <profiles>
         <profile>
             <id>javadocs</id>
+            <dependencies>
+                <!-- provided dependencies from flow/flow-server -->
+                <dependency>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <version>3.1.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>osgi.cmpn</artifactId>
+                    <version>7.0.0</version>
+                    <scope>provided</scope>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>osgi.core</artifactId>
+                    <version>7.0.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <!-- provided dependencies from flow/fusion-endpoint -->
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-web</artifactId>
+                    <version>5.3.14</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-webmvc</artifactId>
+                    <version>5.3.14</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-autoconfigure</artifactId>
+                    <version>2.6.1</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>javadoc-jar</id>


### PR DESCRIPTION
when generating javadoc by using java 11, those dependencies are needed.

we don't have javadoc generation during PR validation, so i skipped ci for this PR