### PR TITLE
feat!: remove fusion-endpoint from vaadin

### DIFF
--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -40,10 +40,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>fusion-endpoint</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

`fusion-endpoint` will be part of Hilla, not Vaadin.

- As a Vaadin Flow user without Endpoints, this change shouldn't affect anything. 
- As a Hilla/Fusion user, it's recommended to change the dependency from `vaadin` to `hilla`, where the Endpoint is included.
- As a hybrid user, could update the pom file to include both `vaadin` and `hilla` dependencies.

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
