### PR TITLE
chore: update vaadin-usage-statistics to 2.1.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -500,7 +500,7 @@
             "npmName": "@vaadin/vaadin-upload"
         },
         "vaadin-usage-statistics": {
-            "jsVersion": "2.1.1",
+            "jsVersion": "2.1.2",
             "npmName": "@vaadin/vaadin-usage-statistics"
         },
         "vaadin-virtual-list": {


### PR DESCRIPTION
## Description

Updated to the version that has correct `"postinstall"` script.
