### PR TITLE
chore: Define jna version

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -95,12 +95,12 @@
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>5.10.0</version>
+                <version>${jna.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna-platform</artifactId>
-                <version>5.10.0</version>
+                <version>${jna.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -15,6 +15,7 @@
     <properties>
 {{javadeps}}
         <slf4j.version>1.7.32</slf4j.version>
+        <jna.version>5.10.0</jna.version>
     </properties>
 
     <distributionManagement>
@@ -89,6 +90,17 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-jcl</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <!-- JNA -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>5.10.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Some libraries like testcontainers (there are others) define a dependency to an older jna version. 
As the jna dependency of the license checker comes from e.g. collab-engine -> license-checker -> oshi-core -> jna it is often overridden by another version.
Having it in the bom guarantees that you get a new enough version that e.g. works on new macs.
