### PR TITLE
chore: use local repo just before prereleases one

### DIFF
--- a/vaadin-platform-gradle-test/build.gradle
+++ b/vaadin-platform-gradle-test/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     repositories {
+        mavenCentral()
         mavenLocal()
         maven { setUrl("https://maven.vaadin.com/vaadin-prereleases") }
-        mavenCentral()
     }
     dependencies {
         classpath group: 'com.vaadin',
@@ -22,9 +22,9 @@ apply plugin: 'com.vaadin.plugin.sauce.SauceConnectPlugin'
 
 repositories {
     mavenCentral()
+    mavenLocal()
     maven { setUrl('https://maven.vaadin.com/vaadin-prereleases') }
     jcenter()
-    mavenLocal()
 }
 
 dependencies {


### PR DESCRIPTION
This asures that in CI tests use the actual compiled and installed platform version