### PR TITLE
chore: remove no longer used iron-a11y-announcer

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -109,11 +109,6 @@
             "jsVersion": "23.0.0-beta3",
             "npmName": "@vaadin/integer-field"
         },
-        "iron-a11y-announcer": {
-            "jsVersion": "2.1.0",
-            "npmName": "@polymer/iron-a11y-announcer",
-            "npmVersion": "3.0.2"
-        },
         "iron-icon": {
             "jsVersion": "2.1.0",
             "npmName": "@polymer/iron-icon",


### PR DESCRIPTION
## Description

Starting from [23.0.0-alpha3](https://github.com/vaadin/web-components/releases/tag/v23.0.0-alpha3), web components use internal logic instead of the legacy `iron-a11y-announcer` dependency.

## Type of change

- Dependency update