### PR TITLE
chore: update parent project to 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.5</version>
         <relativePath />
     </parent>
     <artifactId>vaadin-platform-parent</artifactId>


### PR DESCRIPTION
the older parent version generate invalid url for projects.

