### PR TITLE
chore: remove flow-spring entry from version.json

### DIFF
--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -18,7 +18,7 @@
 
 **Official add-ons and plugins:**
 
-- Spring add-on ({{core.flow-spring.javaVersion}})
+- Spring add-on ({{core.flow.javaVersion}})
 - CDI add-on ([{{core.flow-cdi.javaVersion}}](https://github.com/vaadin/cdi/releases/tag/{{core.flow-cdi.javaVersion}}))
 - Maven plugin ({{platform}})
 - Gradle plugin ({{platform}})

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-spring</artifactId>
-                <version>${flow.spring.version}</version>
+                <version>${flow.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/versions.json
+++ b/versions.json
@@ -84,9 +84,6 @@
         "flow-cdi": {
             "javaVersion": "14.0.0"
         },
-        "flow-spring": {
-            "javaVersion": "23.1-SNAPSHOT"
-        },
         "form-layout": {
             "jsVersion": "23.0.2",
             "npmName": "@vaadin/form-layout"


### PR DESCRIPTION
since Vaadin 23, spring addon has been moved to flow project, so let us remove the separate entry for spring. 