### PR TITLE
chore: update relelase note for v23.1 [skip ci]

### DIFF
--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -1,6 +1,12 @@
+Vaadin {{platform}}
+
 *This is a maintenance release for Vaadin 23.1. See [23.1.0 release notes](https://github.com/vaadin/platform/releases/tag/23.1.0) for details and resources.*
 
-{{changesSincePrevious}}
+**NOTE:**
+- Starting from Vaadin 23, Java 11 is required on your Vaadin apps.
+- Flow starts to follow the platform version
+- Vaadin Spring addon is part of the flow project, following platform versioning
+- Vaadin Fusion has been renamed to [Hilla](https://github.com/vaadin/hilla#hilla), and follows it's own version sequence.
 
 ## Changelogs
 

--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -1,8 +1,14 @@
+Vaadin {{platform}}
+
 [Changelogs](#_changelogs) · [Upgrading guides](#_upgrading_guides) · [Docs](https://vaadin.com/docs/latest/) · [Get Started](https://vaadin.com/start/)
 
-*This is a pre-release for the next major version of Vaadin. We appreciate if you give it a try and [report any issues](https://github.com/vaadin/platform/issues/new) you notice.*
+*This is a pre-release for the Vaadin 23.1. We appreciate if you give it a try and [report any issues](https://github.com/vaadin/platform/issues/new) you notice.*
 
-{{changesSincePrevious}}
+**NOTE:**
+- Starting from Vaadin 23, Java 11 is required on your Vaadin apps.
+- Flow starts to follow the platform version
+- Vaadin Spring addon is part of the flow project, following platform versioning
+- Vaadin Fusion has been renamed to [Hilla](https://github.com/vaadin/hilla#hilla), and follows it's own version sequence.
 
 **NOTE:** 
   - Starting from Vaadin 23, Java 11 is required on your Vaadin apps. 

--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -1,8 +1,14 @@
+Vaadin {{platform}}
+
 [Changelogs](#_changelogs) · [Upgrading guides](#_upgrading_guides) · [Docs](https://vaadin.com/docs/latest/) · [Get Started](https://vaadin.com/start/)
 
-**NOTE:** 
-  - Starting from Vaadin 23, Java 11 is required on your Vaadin apps. 
-  - Vaadin Spring addon version starts to follow flow version
+**NOTE:**
+- Starting from Vaadin 23, Java 11 is required on your Vaadin apps.
+- Flow starts to follow the platform version
+- Vaadin Spring addon is part of the flow project, following platform versioning
+- Vaadin Fusion has been renamed to [Hilla](https://github.com/vaadin/hilla#hilla), and follows it's own version sequence.
+
+## <a id="_changelogs"></a> Changelogs
 
 - Flow ([{{core.flow.javaVersion}}](https://github.com/vaadin/flow/releases/tag/{{core.flow.javaVersion}})) and Hilla (<!-- Insert Version -->) 
 - Design System


### PR DESCRIPTION
- the first row will be used as title for the relelase
- the note is needed, as we got feedback that user get confused with spring and hilla version and name