### PR TITLE
chore: Update license checker and jna version

### DIFF
--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -14,7 +14,7 @@
 
     <properties>
 {{javadeps}}
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <jna.version>5.11.0</jna.version>
     </properties>
 

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -15,7 +15,7 @@
     <properties>
 {{javadeps}}
         <slf4j.version>1.7.32</slf4j.version>
-        <jna.version>5.10.0</jna.version>
+        <jna.version>5.11.0</jna.version>
     </properties>
 
     <distributionManagement>

--- a/versions.json
+++ b/versions.json
@@ -605,7 +605,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.2.2",
+            "javaVersion": "1.4.1",
             "jsVersion": "2.1.2"
         },
         "vaadin-map": {


### PR DESCRIPTION
Update license checker version to 1.4.1
Aligns jna version with license-checker transitive dependencies
Align slf4j version with flow mater 23.1
