### PR TITLE
chore: add lit-renderer package to versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -146,6 +146,10 @@
             "jsVersion": "23.1.0-beta1",
             "npmName": "@vaadin/list-box"
         },
+        "lit-renderer": {
+            "jsVersion": "23.1.0-beta1",
+            "npmName": "@vaadin/lit-renderer"
+        },
         "login": {
             "jsVersion": "23.1.0-beta1",
             "npmName": "@vaadin/login"


### PR DESCRIPTION
## Description

In Vaadin web components 23.1 we added a new package as part of https://github.com/vaadin/web-components/issues/266
Adding it here so its version gets locked, even though it does not depend on any components.