### PR TITLE
fix: Downgrade Flow OSGi to 8.0.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -530,7 +530,7 @@
             "npmName": "@vaadin/crud"
         },
         "flow-osgi": {
-            "javaVersion": "8.0.2"
+            "javaVersion": "8.0.1"
         },
         "grid-pro": {
             "jsVersion": "23.0.10",


### PR DESCRIPTION


## Description

Flow OSGi 8.0.2 is not compatible with 23.0 because of License Checker 1.4.1.

Fixes https://github.com/vaadin/vaadin-flow-karaf-example/issues/100

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
