### PR TITLE
chore: downgrade osgi plugin to 8.0.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -530,7 +530,7 @@
             "npmName": "@vaadin/crud"
         },
         "flow-osgi": {
-            "javaVersion": "8.0.2"
+            "javaVersion": "8.0.1"
         },
         "grid-pro": {
             "jsVersion": "23.0.10",


### PR DESCRIPTION
plugin 8.0.2 is using license checker 1.4.. which should not be included in Vaadin 23.0 https://vaadin.slack.com/archives/CACKS4075/p1654157479207219