### PR TITLE
chore:pack the correct versions.json after previous update

### DIFF
--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -128,7 +128,7 @@
                         </goals>
                         <configuration>
                             <sourceFile>../versions.json</sourceFile>
-                            <destinationFile>${basedir}/target/classes/vaadin_versions.json</destinationFile>
+                            <destinationFile>${basedir}/target/classes/vaadin-versions.json</destinationFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -140,8 +140,8 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <tasks>
-                                <replace token= "{{version}}" value="${version}" dir="target/classes">
-                                    <include name="vaadin_versions.json"/>
+                                <replace token= "{{version}}" value="${project.parent.version}" dir="target/classes">
+                                    <include name="vaadin-versions.json"/>
                                 </replace>
                             </tasks>
                         </configuration>

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -128,7 +128,7 @@
                         </goals>
                         <configuration>
                             <sourceFile>../versions.json</sourceFile>
-                            <destinationFile>${basedir}/target/classes/vaadin-versions.json</destinationFile>
+                            <destinationFile>${basedir}/target/classes/vaadin-core-versions.json</destinationFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -141,7 +141,7 @@
                         <configuration>
                             <tasks>
                                 <replace token= "{{version}}" value="${project.parent.version}" dir="target/classes">
-                                    <include name="vaadin-versions.json"/>
+                                    <include name="vaadin-core-versions.json"/>
                                 </replace>
                             </tasks>
                         </configuration>

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -128,6 +128,8 @@
                         </goals>
                         <configuration>
                             <sourceFile>../versions.json</sourceFile>
+                            <!-- use vaadin-core-versions.json here, as flow check this file firstly. 
+                                 later we should consider to split this file for core and pro components. -->
                             <destinationFile>${basedir}/target/classes/vaadin-core-versions.json</destinationFile>
                         </configuration>
                     </execution>


### PR DESCRIPTION
after https://github.com/vaadin/flow/pull/14014 changes, flow is checking the hardcoded vaadin-versions.json in the jar. 

hilla should be updated accordingly. 

fixes #3089 