### PR TITLE
chore: remove fusion-endpoint from platform

### DIFF
--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -64,11 +64,6 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
-                <artifactId>fusion-endpoint</artifactId>
-                <version>${flow.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-dev-server</artifactId>
                 <version>${flow.version}</version>
             </dependency>


### PR DESCRIPTION
now that fusion-endpoint is hilla-endpoint, the dependency must be brought by hilla bom

