### PR TITLE
Add different URL for MIT license coming from java-jwt

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
@@ -79,6 +79,7 @@ public class LicenseCheckTest {
         whitelist.add("https://jsoup.org/license");
         whitelist.add("http://opensource.org/licenses/mit-license");
         whitelist.add("https://spdx.org/licenses/MIT-0.html");
+        whitelist.add("https://raw.githubusercontent.com/auth0/java-jwt/master/LICENSE");
 
         // Public Domain
         whitelist.add("http://creativecommons.org/publicdomain/zero/1.0/");


### PR DESCRIPTION
Prevents the following failure:
licenses that have not been whitelisted: 
 dependency 'com.auth0:java-jwt' has licenses : [The MIT License (MIT): https://raw.githubusercontent.com/auth0/java-jwt/master/LICENSE]
