### PR TITLE
chore: update CE to 5.0.3

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -562,7 +562,7 @@
             "javaVersion": "23.0.2"
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "5.0.2"
+            "javaVersion": "5.0.3"
         },
         "vaadin-confirm-dialog": {
             "component": true,


### PR DESCRIPTION
starting from this version, CE doesnt have the npmPackage annotation for field-highlighter.

