### PR TITLE
chore: Upgrade license checker

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -396,7 +396,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.2.2",
+            "javaVersion": "1.3.1",
             "jsVersion": "2.1.2"
         },
         "vaadin-rich-text-editor": {

--- a/versions.json
+++ b/versions.json
@@ -396,7 +396,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.2.0",
+            "javaVersion": "1.2.2",
             "jsVersion": "2.1.2"
         },
         "vaadin-rich-text-editor": {


### PR DESCRIPTION
1.2.1+ has some bugfixes regarding headless mode
1.4+ has offline related changes so let's not go there yet