### PR TITLE
chore: update project to 24.0-SNAPSHOT

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1
+      continue-on-error: true
       with:
         repo-token: ${{ secrets.repo_greeting }}
         issue-message: 'Thanks for using Vaadin! We appreciate your help and we’ll take care of this as soon as possible.'

--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <groupId>dev.hilla</groupId>

--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -35,7 +35,7 @@
     </repositories>
 
     <properties>
-        <spring-boot.version>2.7.3</spring-boot.version>
+        <spring-boot.version>3.0.0-M4</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <groupId>dev.hilla</groupId>
     <artifactId>hilla</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <url>https://vaadin.com</url>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <hilla.version>1.3-SNAPSHOT</hilla.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <profile>
             <id>gradle</id>
             <activation>
-                <jdk>(,17]</jdk>
+                <jdk>(,18)</jdk>
             </activation>
             <modules>
                 <module>vaadin-gradle-plugin</module>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <artifactId>vaadin-platform-parent</artifactId>
     <packaging>pom</packaging>
-    <version>23.3-SNAPSHOT</version>
+    <version>24.0-SNAPSHOT</version>
     <name>Vaadin Platform</name>
     <description>Vaadin Platform</description>
     <url>https://vaadin.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,10 @@
             </snapshots>
         </repository>
         <repository>
+            <id>spring milestones</id>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+        <repository>
             <id>apache snapshots</id>
             <url>https://repository.apache.org/content/repositories/snapshots</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,10 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>apache snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
+        </repository>
     </repositories>
     <pluginRepositories>
         <!-- Main Maven repository -->

--- a/scripts/generator/templates/template-hilla-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-hilla-maven-plugin-pom.xml
@@ -19,8 +19,8 @@
 
     <properties>
 {{javadeps}}
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.version>3.8.4</maven.version>

--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -1,12 +1,6 @@
 Vaadin {{platform}}
 
-*This is a maintenance release for Vaadin 23.3. See [23.3.0 release notes](https://github.com/vaadin/platform/releases/tag/23.3.0) for details and resources.*
-
-**NOTE:**
-- Starting from Vaadin 23, Java 11 is required on your Vaadin apps.
-- Flow starts to follow the platform version
-- Vaadin Spring addon is part of the flow project, following platform versioning
-- Vaadin Fusion has been renamed to [Hilla](https://github.com/vaadin/hilla#hilla), and follows it's own version sequence.
+*This is a maintenance release for Vaadin 24.0. See [24.0.0 release notes](https://github.com/vaadin/platform/releases/tag/24.0.0) for details and resources.*
 
 ## Changelogs
 

--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -2,13 +2,7 @@ Vaadin {{platform}}
 
 [Changelogs](#_changelogs) · [Upgrading guides](#_upgrading_guides) · [Docs](https://vaadin.com/docs/latest/) · [Get Started](https://vaadin.com/start/)
 
-*This is a pre-release for the Vaadin 23.3. We appreciate if you give it a try and [report any issues](https://github.com/vaadin/platform/issues/new) you notice.*
-
-**NOTE:**
-- Starting from Vaadin 23, Java 11 is required on your Vaadin apps.
-- Flow starts to follow the platform version
-- Vaadin Spring addon is part of the flow project, following platform versioning
-- Vaadin Fusion has been renamed to [Hilla](https://github.com/vaadin/hilla#hilla), and follows it's own version sequence.
+*This is a pre-release for the Vaadin 24.0. We appreciate if you give it a try and [report any issues](https://github.com/vaadin/platform/issues/new) you notice.*
 
 ## <a id="_changelogs"></a> Changelogs
 

--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -2,27 +2,18 @@ Vaadin {{platform}}
 
 [Changelogs](#_changelogs) · [Upgrading guides](#_upgrading_guides) · [Docs](https://vaadin.com/docs/latest/) · [Get Started](https://vaadin.com/start/)
 
-## New and Noteworthy Since Vaadin 23.0
+## New and Noteworthy Since Vaadin 24.0
 
 ### Flow
-- Support for Liferay 7
-- Vite build tool improvements `*`
-
+- 
 ### Hilla
-- Reactive Endpoints `*`
+- 
 
 ### Design System
-- Lit renderer directives
-- Grid: freeze columns to the end
-- Dialog: header and footer slots
-- Lumo: Java API for CSS utility classes
-- Tree Grid: eager fetch mode
-- Multi-Select Combo Box
+- 
 
 ### Collaboration Engine
-- `FormManager` and `ListOperation` API
-- Clustering support `*`
-
+- 
 `*` experimental
 
 ## <a id="_changelogs"></a> Changelogs

--- a/scripts/generator/templates/template-servlet-containers-tests-pom.xml
+++ b/scripts/generator/templates/template-servlet-containers-tests-pom.xml
@@ -13,8 +13,8 @@
     <description>Vaadin Platform Servlet Containers Tests</description>
     <url>https://vaadin.com</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/scripts/generator/templates/template-vaadin-core-package.json
+++ b/scripts/generator/templates/template-vaadin-core-package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/vaadin-core",
-  "version": "23.3.0",
+  "version": "24.0.0",
   "description": "Vaadin components is an evolving set of free, open sourced custom HTML elements for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
 {{javadeps}}
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <gradle.executable>./gradlew</gradle.executable>

--- a/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
@@ -16,8 +16,8 @@
 
     <properties>
 {{javadeps}}
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.version>3.8.4</maven.version>

--- a/scripts/generator/templates/template-vaadin-package.json
+++ b/scripts/generator/templates/template-vaadin-package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/vaadin",
-  "version": "23.3.0",
+  "version": "24.0.0",
   "description": "Vaadin components is an evolving set of open sourced custom HTML elements for building mobile and desktop web applications in modern browsers.",
   "author": "Vaadin Ltd",
   "license": "(Apache-2.0 OR SEE LICENSE IN https://vaadin.com/license/cvdl-4.0)",

--- a/vaadin-core-jandex/pom.xml
+++ b/vaadin-core-jandex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-core-jandex</artifactId>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-core</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '0.11.0'
-    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.7.20'
     id 'org.jetbrains.dokka' version '1.4.32'
 }
 
@@ -23,8 +23,8 @@ defaultTasks 'jar'
 group pom.parent.groupId
 version = project.hasProperty('vaadin.version') ? project.getProperty('vaadin.version') : pom.parent.version
 archivesBaseName = pom.artifactId
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 17
+targetCompatibility = 17
 
 /***********************************************************************************************************************
  *
@@ -60,6 +60,7 @@ repositories {
     jcenter()
     maven { url = 'https://plugins.gradle.org/m2/' }
     maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
+    maven { url = 'https://repository.apache.org/content/repositories/snapshots' }
 }
 
 dependencies {
@@ -200,6 +201,6 @@ kotlin {
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 }

--- a/vaadin-jandex/pom.xml
+++ b/vaadin-jandex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-jandex</artifactId>

--- a/vaadin-platform-gradle-test/build.gradle
+++ b/vaadin-platform-gradle-test/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id 'war'
-    id 'org.gretty' version '3.0.4'
+    id 'org.gretty' version '4.0.3'
     id 'com.vaadin.plugin.sauce.SauceConnectPlugin' version '0.0.15'
 }
 
@@ -34,7 +34,7 @@ dependencies {
     
     testImplementation 'com.vaadin:vaadin-testbench'
     testImplementation 'junit:junit:4.13'
-    testImplementation 'io.github.bonigarcia:webdrivermanager:4.4.0'
+    testImplementation 'io.github.bonigarcia:webdrivermanager:5.3.0'
     
     providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
@@ -54,7 +54,7 @@ test {
 gretty {
     contextPath = '/'
     httpPort = 8080
-    servletContainer = 'jetty9.4'
+    servletContainer = 'jetty11'
     integrationTestTask = 'integrationTest'
 }
 

--- a/vaadin-platform-gradle-test/build.gradle
+++ b/vaadin-platform-gradle-test/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     testImplementation 'com.vaadin:vaadin-testbench'
     testImplementation 'junit:junit:4.13'
     testImplementation 'io.github.bonigarcia:webdrivermanager:4.4.0'
-
-    providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
+    
+    providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
 
     // logging through the SLF4J API to SLF4J-Simple. See src/main/resources/simplelogger.properties for logger configuration
     implementation 'org.slf4j:slf4j-simple:1.7.30'

--- a/vaadin-platform-gradle-test/gradle.properties
+++ b/vaadin-platform-gradle-test/gradle.properties
@@ -1,3 +1,3 @@
-vaadinVersion=23.3-SNAPSHOT
-pluginVersion=23.3-SNAPSHOT
+vaadinVersion=24.0-SNAPSHOT
+pluginVersion=24.0-SNAPSHOT
 org.gradle.daemon=false

--- a/vaadin-platform-hybrid-test/pom-dev-mode.xml
+++ b/vaadin-platform-hybrid-test/pom-dev-mode.xml
@@ -13,8 +13,8 @@
     <description>Vaadin Platform Hybrid Tests (Dev Mode)</description>
     <url>https://vaadin.com</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -13,8 +13,8 @@
     <description>Vaadin Platform Hybrid (flow and fusion views) Tests (Production Mode)</description>
     <url>https://vaadin.com</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-platform-hybrid-test-prod</artifactId>
     <packaging>war</packaging>

--- a/vaadin-platform-javadoc/pom.xml
+++ b/vaadin-platform-javadoc/pom.xml
@@ -50,9 +50,9 @@
             <dependencies>
                 <!-- provided dependencies from flow/flow-server -->
                 <dependency>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                    <version>3.1.0</version>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
+                    <version>5.0.0</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/vaadin-platform-javadoc/pom.xml
+++ b/vaadin-platform-javadoc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-platform-javadoc</artifactId>
     <packaging>jar</packaging>

--- a/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-servlet-containers-tests</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>platform-test-bnd</artifactId>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -90,9 +90,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -293,12 +293,8 @@
                             <stopPort>9999</stopPort>
                             <stopWait>5</stopWait>
                             <stopKey>foo</stopKey>
-                            <scanIntervalSeconds>1</scanIntervalSeconds>
                             <systemProperties>
-                                <systemProperty>
-                                    <name>vaadin.ce.dataDir</name>
-                                    <value>${project.build.directory}</value>
-                                </systemProperty>
+                                <vaadin.ce.dataDir>${project.build.directory}</vaadin.ce.dataDir>
                             </systemProperties>
                         </configuration>
                         <executions>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -288,7 +288,7 @@
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-maven-plugin</artifactId>
-                        <version>9.4.36.v20210114</version>
+                        <version>11.0.8</version>
                         <configuration>
                             <stopPort>9999</stopPort>
                             <stopWait>5</stopWait>
@@ -306,7 +306,7 @@
                                 <id>start-jetty</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
-                                    <goal>deploy-war</goal>
+                                    <goal>start-war</goal>
                                 </goals>
                             </execution>
                             <execution>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -13,8 +13,8 @@
     <description>Vaadin Platform Tests</description>
     <url>https://vaadin.com</url>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -296,7 +296,7 @@
                             <systemProperties>
                                 <vaadin.ce.dataDir>${project.build.directory}</vaadin.ce.dataDir>
                             </systemProperties>
-                        </configuration>
+                        </configuration>    
                         <executions>
                             <execution>
                                 <id>start-jetty</id>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-platform-test</artifactId>
     <packaging>war</packaging>

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/CustomServletDeployer.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/CustomServletDeployer.java
@@ -15,11 +15,11 @@
  */
 package com.vaadin.platform.test;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
-import javax.servlet.ServletRegistration;
-import javax.servlet.annotation.WebListener;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.annotation.WebListener;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinServlet;

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/osgi/Activator.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/osgi/Activator.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.platform.test.osgi;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
 
 import java.util.Hashtable;
 

--- a/vaadin-quarkus-extension/pom.xml
+++ b/vaadin-quarkus-extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-extension</artifactId>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -33,7 +33,7 @@
     </repositories>
 
     <properties>
-        <spring-boot.version>2.7.3</spring-boot.version>
+        <spring-boot.version>3.0.0-M4</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-spring-boot-starter</artifactId>

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-testbench</artifactId>
     <packaging>jar</packaging>

--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-platform-parent</artifactId>
-        <version>23.3-SNAPSHOT</version>
+        <version>24.0-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin</artifactId>
     <packaging>jar</packaging>

--- a/versions.json
+++ b/versions.json
@@ -84,7 +84,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "23.3.0.alpha1"
+            "javaVersion": "24.0.0.alpha1"
         },
         "flow-cdi": {
             "javaVersion": "14.0.1"


### PR DESCRIPTION
- update project to 24.0-SNAPSHOT
- add apache snapshot repo
- add spring milestone repo
- replace javax.servlet-api with jakarta.servlet-api
- update jetty-maven-plugin
- update gradle settings
  - java support version
  - add maven repo
  - update kotlin.jvm version