### PR TITLE
chore: use latest ci-sauce

### DIFF
--- a/vaadin-platform-hybrid-test/pom-dev-mode.xml
+++ b/vaadin-platform-hybrid-test/pom-dev-mode.xml
@@ -295,7 +295,7 @@
                             <dependency>
                                 <groupId>com.saucelabs</groupId>
                                 <artifactId>ci-sauce</artifactId>
-                                <version>1.151</version>
+                                <version>1.161</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -208,7 +208,7 @@
                             <dependency>
                                 <groupId>com.saucelabs</groupId>
                                 <artifactId>ci-sauce</artifactId>
-                                <version>1.151</version>
+                                <version>1.161</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
+++ b/vaadin-platform-servlet-containers-tests/bnd-tools-test/pom.xml
@@ -327,7 +327,7 @@
                             <dependency>
                                 <groupId>com.saucelabs</groupId>
                                 <artifactId>ci-sauce</artifactId>
-                                <version>1.151</version>
+                                <version>1.161</version>
                             </dependency>
                         </dependencies>
                         <executions>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -261,7 +261,7 @@
                             <dependency>
                                 <groupId>com.saucelabs</groupId>
                                 <artifactId>ci-sauce</artifactId>
-                                <version>1.151</version>
+                                <version>1.161</version>
                             </dependency>
                         </dependencies>
                         <executions>


### PR DESCRIPTION
> We will be deprecating Sauce Connect Proxy versions 4.6.2, 4.6.3, 4.6.4, and 4.6.5, effective November 30, 2022.

Currently ci-sauce-1.151.jar brings sc-4.6.2 which will be deprecated