### PR TITLE
chore: provide dependency for javadoc generation

### DIFF
--- a/vaadin-platform-javadoc/pom.xml
+++ b/vaadin-platform-javadoc/pom.xml
@@ -87,6 +87,12 @@
                     <version>2.6.6</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                    <version>3.1.0</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
the `javax.servlet-api` dependency is removed from flow, but CE and other modules (potentially) are still using it. 
provide this dependency here for javadoc generation