### PR TITLE
chore: update vaadin-parent to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.1.0</version>
         <relativePath />
     </parent>
     <artifactId>vaadin-platform-parent</artifactId>


### PR DESCRIPTION
for JDK 17 support
