### PR TITLE
test: do not use deprecated default slot

### DIFF
--- a/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
+++ b/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
@@ -145,9 +145,9 @@ export class ComponentsView extends View {
           </vaadin-chart-series>
         </vaadin-chart>
         <vaadin-checkbox-group label="Label" theme="vertical">
-          <vaadin-checkbox value="1" checked>Option one</vaadin-checkbox>
-          <vaadin-checkbox value="2">Option two</vaadin-checkbox>
-          <vaadin-checkbox value="3">Option three</vaadin-checkbox>
+          <vaadin-checkbox value="1" label="Option one" checked></vaadin-checkbox>
+          <vaadin-checkbox value="2" label="Option two"></vaadin-checkbox>
+          <vaadin-checkbox value="3" label="Option three"></vaadin-checkbox>
         </vaadin-checkbox-group>
         <vaadin-combo-box .items="${[1,2,3,4,5]}"></vaadin-combo-box>
         <vaadin-multi-select-combo-box .items="${['apple', 'banana', 'lemon', 'orange']}"></vaadin-multi-select-combo-box>
@@ -239,9 +239,9 @@ export class ComponentsView extends View {
         ]}"></vaadin-menu-bar>
 
         <vaadin-radio-group label="Label" theme="vertical">
-          <vaadin-radio-button checked>Option one</vaadin-radio-button>
-          <vaadin-radio-button>Option two</vaadin-radio-button>
-          <vaadin-radio-button>Option three</vaadin-radio-button>
+          <vaadin-radio-button label="Option one" checked></vaadin-radio-button>
+          <vaadin-radio-button label="Option two"></vaadin-radio-button>
+          <vaadin-radio-button label="Option three"></vaadin-radio-button>
         </vaadin-radio-group>
 
         <vaadin-rich-text-editor></vaadin-rich-text-editor>


### PR DESCRIPTION
## Description

The default slot in `vaadin-checkbox` and `vaadin-radio-button` is deprecated and might be removed in V24.
Updated the ITs to use `label` property instead, to align with other components e.g. `vaadin-text-field`.

## Type of change

- Tests