### PR TITLE
chore: update vaadin-quarkus to 2.0.0.alpha2 for Vaadin 24

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
@@ -43,6 +43,7 @@ public class LicenseCheckTest {
         whitelist.add("http://www.eclipse.org/legal/epl-2.0");
         whitelist.add("https://www.eclipse.org/legal/epl-v20.html");
         whitelist.add("https://projects.eclipse.org/license/epl-2.0");
+		whitelist.add("https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt");
         
         // Mozilla
         whitelist.add("http://www.mozilla.org/MPL/MPL-1.1.html");
@@ -106,6 +107,7 @@ public class LicenseCheckTest {
         
         // GNU General Public License
         whitelist.add("https://projects.eclipse.org/license/secondary-gpl-2.0-cp");
+		whitelist.add("https://www.gnu.org/software/classpath/license.html");
 
         //CDDL + GPLv2 with classpath exception
         whitelist.add("https://oss.oracle.com/licenses/CDDL+GPL-1.1");

--- a/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/LicenseCheckTest.java
@@ -70,6 +70,7 @@ public class LicenseCheckTest {
         // BSD
         whitelist.add("http://www.opensource.org/licenses/bsd-license.php");
         whitelist.add("http://opensource.org/licenses/BSD-2-Clause");
+        whitelist.add("https://opensource.org/licenses/BSD-2-Clause");
         whitelist.add("http://opensource.org/licenses/BSD-3-Clause");
 
         // MIT

--- a/versions.json
+++ b/versions.json
@@ -258,7 +258,7 @@
             "npmName": "@vaadin/progress-bar"
         },
         "vaadin-quarkus": {
-            "javaVersion": "1.1.2"
+            "javaVersion": "2.0.0.alpha1"
         },
         "radio-group": {
             "javaVersion": "{{version}}",

--- a/versions.json
+++ b/versions.json
@@ -258,7 +258,7 @@
             "npmName": "@vaadin/progress-bar"
         },
         "vaadin-quarkus": {
-            "javaVersion": "2.0.0.alpha1"
+            "javaVersion": "2.0.0.alpha2"
         },
         "radio-group": {
             "javaVersion": "{{version}}",


### PR DESCRIPTION
Update vaadin-quarkus to 2.0.0.alpha2 for Vaadin 24