### PR TITLE
chore: update gretty version

### DIFF
--- a/vaadin-platform-gradle-test/build.gradle
+++ b/vaadin-platform-gradle-test/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id 'war'
-    id 'org.gretty' version '3.0.4'
+    id 'org.gretty' version '3.0.9'
     id 'com.vaadin.plugin.sauce.SauceConnectPlugin' version '0.0.15'
 }
 


### PR DESCRIPTION
currently gradle portal has failed, 3.0.4 doesn't have artifacts in maven, let us try with the newer version which is available at both nexus

