### PR TITLE
chore: Upgrade license checker to 1.11.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -358,7 +358,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.11.1"
+            "javaVersion": "1.11.2"
         },
         "vaadin-spreadsheet": {
             "javaVersion": "{{version}}",


### PR DESCRIPTION
Fixes OSGi compatibility
