### PR TITLE
chore: Remove flow-polymer-template from vaadin-core

### DIFF
--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -48,10 +48,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-polymer-template</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-push</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is now Prime+ and must be manually added as a dependency when you use it
