### PR TITLE
chore: add kits to vaadin-bom and releasenote (23.3) [skip ci]

### DIFF
--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -41,7 +41,7 @@ function createPackageJson(versions, packageJsonTemplate) {
 @param {String} mavenTemplate template string to replace versions in.
 */
 function createMaven(versions, mavenTemplate) {
-    const allVersions = Object.assign({}, versions.core, versions.vaadin);
+    const allVersions = Object.assign({}, versions.core, versions.vaadin, versions.kits);
     const includedProperties = computeUsedProperties(mavenTemplate);
 
     let mavenDeps = '';

--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -32,3 +32,6 @@ Vaadin {{platform}}
 - OSGi plugin ([{{vaadin.flow-osgi.javaVersion}}](https://github.com/vaadin/osgi/releases/tag/{{vaadin.flow-osgi.javaVersion}}))
 - Quarkus plugin ([{{core.vaadin-quarkus.javaVersion}}](https://github.com/vaadin/quarkus/releases/tag/{{core.vaadin-quarkus.javaVersion}}))
 - Portlet plugin ([{{vaadin.vaadin-portlet.javaVersion}}](https://github.com/vaadin/portlet/releases/tag/{{vaadin.vaadin-portlet.javaVersion}}))
+- Kubernetes Kit ([{{kits.kubernets-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernets-kit-starter.javaVersion}}))
+- SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))
+- Observability Kit ([{{kits.observability-kit.version}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit.version}}))

--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -34,5 +34,8 @@ Vaadin {{platform}}
 - OSGi plugin ([{{vaadin.flow-osgi.javaVersion}}](https://github.com/vaadin/osgi/releases/tag/{{vaadin.flow-osgi.javaVersion}}))
 - Quarkus plugin ([{{core.vaadin-quarkus.javaVersion}}](https://github.com/vaadin/quarkus/releases/tag/{{core.vaadin-quarkus.javaVersion}}))
 - Portlet plugin ([{{vaadin.vaadin-portlet.javaVersion}}](https://github.com/vaadin/portlet/releases/tag/{{vaadin.vaadin-portlet.javaVersion}}))
+- Kubernetes Kit ([{{kits.kubernets-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernets-kit-starter.javaVersion}}))
+- SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))
+- Observability Kit ([{{kits.observability-kit.version}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit.version}}))
 
 

--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -47,6 +47,9 @@ Vaadin {{platform}}
 - OSGi plugin ([{{vaadin.flow-osgi.javaVersion}}](https://github.com/vaadin/osgi/releases/tag/{{vaadin.flow-osgi.javaVersion}}))
 - Quarkus plugin ([{{core.vaadin-quarkus.javaVersion}}](https://github.com/vaadin/quarkus/releases/tag/{{core.vaadin-quarkus.javaVersion}}))
 - Portlet plugin ([{{vaadin.vaadin-portlet.javaVersion}}](https://github.com/vaadin/portlet/releases/tag/{{vaadin.vaadin-portlet.javaVersion}}))
+- Kubernetes Kit ([{{kits.kubernets-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernets-kit-starter.javaVersion}}))
+- SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))
+- Observability Kit ([{{kits.observability-kit.version}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit.version}}))
 
 
 ## <a id="_upgrading_guides"></a> Upgrading guides

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -71,6 +71,18 @@
                 <artifactId>collaboration-engine</artifactId>
                 <version>${vaadin.collaboration.engine.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>kubernets-kit-starter</artifactId>
+                <version>${kubernets.kit.starter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>sso-kit-starter</artifactId>
+                <version>${sso.kit.starter.version}</version>
+            </dependency>
             <!-- SLF4J -->
             <dependency>
                 <groupId>org.slf4j</groupId>

--- a/versions.json
+++ b/versions.json
@@ -549,6 +549,9 @@
         "kubernets-kit-starter": {
             "javaVersion": "1.0.0.beta1"
         },
+        "observability-kit": {
+            "version": "1.0.0.rc2"
+        },
         "sso-kit-starter": {
             "javaVersion": "1.0.0.rc2"
         }

--- a/versions.json
+++ b/versions.json
@@ -545,6 +545,14 @@
             "npmName": "@vaadin/virtual-list"
         }
     },
+    "kits": {
+        "kubernets-kit-starter": {
+            "javaVersion": "1.0.0.beta1"
+        },
+        "sso-kit-starter": {
+            "javaVersion": "1.0.0.rc2"
+        }
+    },
     "platform": "{{version}}",
     "react": {
         "react-components": {


### PR DESCRIPTION
you can test with running 
 `./scripts/generateBoms.sh` at the root of platform
then check the generated `pom.xml` under `vaadin-bom` folder