### PR TITLE
chore: fixes before final 23.3 [skip ci]

### DIFF
--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -30,7 +30,6 @@ NOTE: Since Vaadin 23.3, Vaadin Commercial license and Service Terms has been up
 - Stable **Spreadsheet** component for flow
 - New component: **TabSheet**
 - New component: **Tooltip** 
-- Chain validation in inputs: 1. web-component, 2. Flow component, 3. Binder.
 - **DatePicker**: 2-digit year parsing
 - Shift-click for **Grid** multi-sort
 

--- a/versions.json
+++ b/versions.json
@@ -625,9 +625,6 @@
         "vaadin-classic-components": {
             "javaVersion": "23.3.0.rc1"
         },
-        "vaadin-collaboration-engine": {
-            "javaVersion": "5.3.0.rc1"
-        },
         "vaadin-cookie-consent": {
             "component": true,
             "javaVersion": "{{version}}",


### PR DESCRIPTION
duplicated entry for collaboration-engine
chain validation will land in V24