### PR TITLE
chore: update PIT.yml to get rid of warnings (#3432) (CP: 23.3) [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -72,7 +72,7 @@ jobs:
           done
           M=`echo $M | sed -e s/,$//`']}'
           echo "$M"
-          echo "::set-output name=matrix::$M"
+          echo "matrix=$M" >> $GITHUB_OUTPUT
   run:
     needs: prepare
     strategy:
@@ -109,7 +109,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: stCarolas/setup-maven@v4
+      - uses: stCarolas/setup-maven@v4.5
         with:
           maven-version: '3.8.2'
       - run: |

--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -124,7 +124,7 @@ jobs:
           GHTK=${{secrets.GHTK}} ./pit/scripts/pit/run.sh $ARG
         shell: bash
       - if: ${{failure()}}
-        uses: actions/upload-artifact@v2.2.0
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: failed-outputs
           path: tmp/**/*.out


### PR DESCRIPTION
* update PIT.yml to get rid of warnings

* get rid of the set-output usage

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

