### PR TITLE
chore: temporary fix TB vulnerabilities in platform

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -58,10 +58,10 @@ jobs:
           wget https://github.com/devops-kung-fu/bomber/releases/download/v0.4.0/bomber_0.4.0_linux_amd64.deb
           sudo dpkg -i bomber_0.4.0_linux_amd64.deb
       - run: |
-          # Install dependency-check-7.4.4
+          # Install dependency-check-8.0.0
           cd /tmp
-          wget https://github.com/jeremylong/DependencyCheck/releases/download/v7.4.4/dependency-check-7.4.4-release.zip
-          unzip dependency-check-7.4.4-release.zip
+          wget https://github.com/jeremylong/DependencyCheck/releases/download/v8.0.0/dependency-check-8.0.0-release.zip
+          unzip dependency-check-8.0.0-release.zip
           sudo ln -s /tmp/dependency-check/bin/dependency-check.sh /usr/bin/dependency-check
       - run: |
           mkdir -p ~/.vaadin/

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -39,6 +39,53 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- TEMPORARY FIX OF DEP VULNERABILITIES -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>4.1.87.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>2.12.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-kqueue</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Flow HTML components -->
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/versions.json
+++ b/versions.json
@@ -347,7 +347,7 @@
             "javaVersion": "23.2.0"
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "6.0.0.alpha1"
+            "javaVersion": "6.0-SNAPSHOT"
         },
         "vaadin-core": {
             "jsVersion": "{{version}}",


### PR DESCRIPTION
Pinned dependencies should be reverted when
- CE releases a new alpha
- [async-http-client](https://github.com/AsyncHttpClient/async-http-client) releases [3.0.0](https://github.com/AsyncHttpClient/async-http-client/issues/1846) and selenium releases a version with that