### PR TITLE
fix: do not add the feature flags file to dev-bundle jar

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -69,6 +69,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/*Fake*</exclude>
+                        <exclude>**/vaadin-featureflags.properties</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The feature flags file should not be included in the dev-bundle jar
as it then controls the application build if the application doesn't contain
it's own feature flags file.