### PR TITLE
chore: Simplify production mode specification

### DIFF
--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -272,15 +272,6 @@
                     <name>vaadin.productionMode</name>
                 </property>
             </activation>
-            <properties>
-                <vaadin.productionMode>true</vaadin.productionMode>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>flow-server-production-mode</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -292,12 +283,8 @@
                                 <goals>
                                     <goal>build-frontend</goal>
                                 </goals>
-                                <phase>compile</phase>
                             </execution>
                         </executions>
-                        <configuration>
-                            <productionMode>true</productionMode>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -287,17 +287,6 @@
                     <name>vaadin.productionMode</name>
                 </property>
             </activation>
-            <properties>
-                <vaadin.productionMode>true</vaadin.productionMode>
-            </properties>
-
-            <dependencies>
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>flow-server-production-mode</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
@@ -308,12 +297,8 @@
                                 <goals>
                                     <goal>build-frontend</goal>
                                 </goals>
-                                <phase>compile</phase>
                             </execution>
                         </executions>
-                        <configuration>
-                            <productionMode>true</productionMode>
-                        </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
the productionMode parameter has not been needed since https://github.com/vaadin/flow/pull/15390