### PR TITLE
chore: update CE to 5.2.1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -587,7 +587,7 @@
             "javaVersion": "23.2.0"
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "5.2.0"
+            "javaVersion": "5.2.1"
         },
         "vaadin-cookie-consent": {
             "component": true,


### PR DESCRIPTION
updated the vulnerable jackson-databinding