### PR TITLE
chore: exclude the never used JS files

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -90,6 +90,9 @@
                             <resources>
                                 <resource>
                                     <directory>src/main/dev-bundle</directory>
+                                    <excludes>
+                                        <exclude>webapp/VAADIN/build/*.js</exclude>
+                                    </excludes>
                                 </resource>
                             </resources>
                         </configuration>


### PR DESCRIPTION
fixes #3807 