### PR TITLE
fix: Add PWA to the default bundle

### DIFF
--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
@@ -3,9 +3,11 @@ package com.vaadin.devbundle;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
 
 @Theme("vaadin-dev-bundle")
+@PWA(name = "vaadin-dev-bundle", shortName = "vaadin-dev-bundle")
 @JsModule("@vaadin-component-factory/vcf-nav")
 @NpmPackage(value = "line-awesome", version = "1.3.0")
 @NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
@@ -39,6 +39,15 @@ public class DefaultDevBundleIT extends AbstractPlatformTest {
         Assert.assertFalse("Error: folder '" + nodeModules.getPath() + "' shouldn't exist.", nodeModules.exists());
     }
 
+    @Test
+    public void serviceWorkerIsIncludedAndServed() {
+        getDriver().get(getRootURL() + "/sw.js");
+        String pageSource = getDriver().getPageSource();
+        Assert.assertFalse("Service Worker is not served properly",
+                pageSource.contains("Error 404 Not Found")
+                || pageSource.contains("Could not navigate to"));
+    }
+
     @After
     public void tearDown() throws Exception {
         // close the browser instance when all tests are done


### PR DESCRIPTION
This is needed to include sw.js to the default bundle, so making a new bundle isn't needed if PWA is used in the app.

Depends on https://github.com/vaadin/flow/pull/15989

Related-to https://github.com/vaadin/flow/issues/15970