### PR TITLE
fix: Make vaadin depend on vaadin-core instead of vaadin-dev

### DIFF
--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev</artifactId>
+            <artifactId>vaadin-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
This should allow exclusion of vaadin-dev from the production bundle

