### PR TITLE
fix: Make vaadin depend on vaadin-core instead of vaadin-dev (CP:24.0)

### DIFF
--- a/vaadin/pom.xml
+++ b/vaadin/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev</artifactId>
+            <artifactId>vaadin-core</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/versions.json
+++ b/versions.json
@@ -98,7 +98,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.0.0.beta4"
+            "javaVersion": "24.0-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "15.0.0.beta1"


### PR DESCRIPTION
This should allow exclusion of vaadin-dev from the production bundle

