### PR TITLE
fix: maven 3.8.2 and 3.8.3 are broken [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -112,7 +112,7 @@ jobs:
           distribution: 'temurin'
       - uses: stCarolas/setup-maven@v4.5
         with:
-          maven-version: '3.8.2'
+          maven-version: '3.9.0'
       - run: |
           # PIT TESTS ${{matrix.app}} ${{github.event.inputs.version}}
           [ -n "${{github.event.inputs.version}}" ] && ARG="--version=${{github.event.inputs.version}}"


### PR DESCRIPTION
Fixes: https://github.com/vaadin/flow/issues/16097 
Related to: regression described at https://maven.apache.org/docs/3.8.4/release-notes.html

