### PR TITLE
chore: Exclude line-awesome from default dev-bundle

### DIFF
--- a/vaadin-dev-bundle/frontend/themes/vaadin-dev-bundle/theme.json
+++ b/vaadin-dev-bundle/frontend/themes/vaadin-dev-bundle/theme.json
@@ -1,9 +1,3 @@
 {
-  "lumoImports": ["typography", "color", "spacing", "badge", "utility"],
-  "assets": {
-    "line-awesome": {
-      "dist/line-awesome/css/**": "line-awesome/dist/line-awesome/css",
-      "dist/line-awesome/fonts/**": "line-awesome/dist/line-awesome/fonts"
-    }
-  }
+  "lumoImports": ["typography", "color", "spacing", "badge", "utility"]
 }


### PR DESCRIPTION
Because it was only added for start.vaadin.com that doesn't use it anymore.