### PR TITLE
chore: use spring-boot-bom for dependencies [skip ci]

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -26,6 +26,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-bom</artifactId>
                 <version>${project.version}</version>
@@ -122,13 +129,11 @@
                 <dependency>
                     <groupId>org.springframework.data</groupId>
                     <artifactId>spring-data-commons</artifactId>
-                    <version>${spring-boot.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-autoconfigure</artifactId>
-                    <version>${spring-boot.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
this fixes the javadoc generation in snapshot build https://bender.vaadin.com/buildConfiguration/VaadinPlatform_TestReleasePlatformSnapshotToMavenVaadinPrerelease/384063?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true