### PR TITLE
chore: provide the dependencies for javadoc generation [skip ci]

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -166,6 +166,18 @@
                     <version>${junit.jupiter.version}</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>jakarta.websocket</groupId>
+                    <artifactId>jakarta.websocket-client-api</artifactId>
+                    <version>2.1.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.websocket</groupId>
+                    <artifactId>jakarta.websocket-api</artifactId>
+                    <version>2.1.0</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
the scope of these dependencies have been changed on flow side, https://github.com/vaadin/flow/commit/609e66a9563ceae5e16ecd0711c2e049ab4b7b68

