### PR TITLE
fixes: provided jakarta-annotation-api dependency for javadoc [skip ci]

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -178,6 +178,12 @@
                     <version>2.1.0</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                    <version>2.1.1</version>
+                    <scope>provided</scope>
+                </dependency>
             </dependencies>
             <build>
                 <plugins>


### PR DESCRIPTION
this dependency is coming from `flow-server` module which has been updated by this commit https://github.com/vaadin/flow/pull/16223
