### PR TITLE
chore: remove unnecessary spring versions [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,6 @@
         <maven.compiler.target>17</maven.compiler.target>
         <hilla.version>2.1-SNAPSHOT</hilla.version>
         <spring.boot.version>3.0.4</spring.boot.version>
-        <spring.version>6.0.7</spring.version>
-        <spring.security.version>6.0.2</spring.security.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <jetty.version>11.0.13</jetty.version>
     </properties>

--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -87,43 +87,36 @@
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-web</artifactId>
-                    <version>${spring.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-core</artifactId>
-                    <version>${spring.security.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-config</artifactId>
-                    <version>${spring.security.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-oauth2-jose</artifactId>
-                    <version>${spring.security.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-oauth2-resource-server</artifactId>
-                    <version>${spring.security.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-test</artifactId>
-                    <version>${spring.security.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-webmvc</artifactId>
-                    <version>${spring.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
@@ -139,19 +132,16 @@
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context</artifactId>
-                    <version>${spring.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-beans</artifactId>
-                    <version>${spring.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-core</artifactId>
-                    <version>${spring.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
the spring dependency version will come from the `spring-boot-dependencies` bom. 