### PR TITLE
Revert "chore: Upgrade license checker to 1.12.3 (#3967) (#3969)" [skip ci]

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -380,7 +380,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.12.3"
+            "javaVersion": "1.12.2"
         },
         "vaadin-spreadsheet": {
             "javaVersion": "{{version}}",


### PR DESCRIPTION
This reverts commit bd7c97547aa24441e052aaff184ffd83918620af.

as flow didn't take this change yet ... 