### PR TITLE
update license-checker to 1.12.3  [skip ci]

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -380,7 +380,7 @@
             "pro": true
         },
         "vaadin-license-checker": {
-            "javaVersion": "1.12.2"
+            "javaVersion": "1.12.3"
         },
         "vaadin-spreadsheet": {
             "javaVersion": "{{version}}",


### PR DESCRIPTION
this version has not been included in Flow release. merge PR after https://github.com/vaadin/flow/pull/16392 and Vaadin 24.0.2 release