### PR TITLE
Revert "chore: Upgrade vcf-nav to 1.1.1 (#3989) (CP: 24.0)"

### DIFF
--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
@@ -10,7 +10,7 @@ import com.vaadin.flow.theme.Theme;
 @PWA(name = "vaadin-dev-bundle", shortName = "vaadin-dev-bundle")
 @JsModule("@vaadin-component-factory/vcf-nav")
 @NpmPackage(value = "line-awesome", version = "1.3.0")
-@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.1.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
 public class FakeAppConf implements AppShellConfigurator{
 
 }


### PR DESCRIPTION
Reverts vaadin/platform#3990

This update will cause us problems with the default bundle. We need to figure out the proper approach for 24.1 instead