### PR TITLE
Revert "chore: temporally disable safari test (#3868)"

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -26,7 +26,7 @@ public class ComponentsIT extends AbstractPlatformTest {
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             String browsers = System.getProperty("grid.browsers");
             if (browsers == null || browsers.isEmpty()) {
-                Parameters.setGridBrowsers("firefox,edge");
+                Parameters.setGridBrowsers("firefox,safari,edge");
             } else {
                 Parameters.setGridBrowsers(browsers);
             }

--- a/versions.json
+++ b/versions.json
@@ -98,7 +98,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.1.0.alpha1"
+            "javaVersion": "24.1-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "15.0.0"


### PR DESCRIPTION
This reverts commit 9689a59c824214d24fd19a3e525adfcd78ace695.
fixes #3867 
