### PR TITLE
chore: add spring-web to known cve list

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -38,7 +38,6 @@ const licenseWhiteList = [
 ];
 
 const cveWhiteList = {
-  'pkg:maven/org.springframework/spring-web@5.3.24' : ['CVE-2016-1000027'],
   'pkg:maven/org.springframework/spring-web@5.3.26' : ['CVE-2016-1000027']
 }
 

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -38,7 +38,8 @@ const licenseWhiteList = [
 ];
 
 const cveWhiteList = {
-  'pkg:maven/org.springframework/spring-web@5.3.24' : ['CVE-2016-1000027']
+  'pkg:maven/org.springframework/spring-web@5.3.24' : ['CVE-2016-1000027'],
+  'pkg:maven/org.springframework/spring-web@5.3.26' : ['CVE-2016-1000027']
 }
 
 const STYLE = `<style>


### PR DESCRIPTION
We will keep using spring 5 in Vaadin 23. so we cannot really update here. 
the same CVE has been added to the whitelist and now it is just an updated version of spring. 