### PR TITLE
feat: Add default production bundle module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ vaadin-gradle-plugin/pom.xml
 vaadin-gradle-plugin/pom*xml
 vaadin-platform-javadoc/pom.xml
 vaadin-dev-bundle/pom.xml
+vaadin-prod-bundle/pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>vaadin-spring-boot-starter</module>
         <module>vaadin-platform-javadoc</module>
         <module>vaadin-dev-bundle</module>
+        <module>vaadin-prod-bundle</module>
     </modules>
 
     <profiles>

--- a/scripts/generateBoms.sh
+++ b/scripts/generateBoms.sh
@@ -30,5 +30,6 @@ cp scripts/generator/results/vaadin-gradle-plugin-portal-pom.xml vaadin-gradle-p
 cp scripts/generator/results/vaadin-core-versions.json vaadin-core-internal/vaadin-core-versions.json
 cp scripts/generator/results/vaadin-versions.json vaadin-internal/vaadin-versions.json
 cp scripts/generator/results/vaadin-dev-bundle-pom.xml vaadin-dev-bundle/pom.xml
+cp scripts/generator/results/vaadin-prod-bundle-pom.xml vaadin-prod-bundle/pom.xml
 cp scripts/generator/results/hilla-versions.json hilla/hilla-versions.json
 cp scripts/generator/results/hilla-react-versions.json hilla-react/hilla-react-versions.json

--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -84,6 +84,9 @@ const mavenHillaBomResultFileName = getResultsFilePath('hilla-bom.xml');
 const devBundleTemplateFileName = getTemplateFilePath('template-dev-bundle-pom.xml');
 const devBundlePomResultFileName = getResultsFilePath('vaadin-dev-bundle-pom.xml');
 
+const prodBundleTemplateFileName = getTemplateFilePath('template-prod-bundle-pom.xml');
+const prodBundlePomResultFileName = getResultsFilePath('vaadin-prod-bundle-pom.xml');
+
 const platform=argv['platform'];
 const versions = transformer.transformVersions(inputVersions, platform, argv['useSnapshots']);
 
@@ -125,4 +128,5 @@ writer.writeProperty(versions, "flow", gradlePortalPluginTemplatePomFileName, gr
 writer.writeProperty(versions, "flow", platformJavadocTemplatePomFileName, platformJavadocResultPomFileName);
 
 writer.writeProperty(versions, "flow", devBundleTemplateFileName, devBundlePomResultFileName);
+writer.writeProperty(versions, "flow", prodBundleTemplateFileName, prodBundlePomResultFileName);
 

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -1,0 +1,121 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-platform-parent</artifactId>
+        <version>{{platform}}</version>
+    </parent>
+    <artifactId>vaadin-prod-bundle</artifactId>
+    <packaging>jar</packaging>
+    <name>Vaadin Prod Bundle</name>
+    <description>Vaadin Prod Bundle</description>
+    <url>https://vaadin.com</url>
+
+    <distributionManagement>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+        </repository>
+    </distributionManagement>
+
+    <properties>
+        {{javadeps}}
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-internal</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spreadsheet-flow</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*Fake*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                  <execution>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>run</goal>
+                    </goals>
+                    <configuration>
+                      <target>
+                        <!-- Remove application class file, so as IT modules do not read @Theme annotations when
+                             maven configures the classpath for multimodule projects -->
+                        <delete dir="target/classes/com/vaadin/prodbundle" includeemptydirs="true"></delete>
+                      </target>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -93,6 +93,7 @@
                 <executions>
                     <execution>
                         <goals>
+                            <goal>prepare-frontend</goal>
                             <goal>build-frontend</goal>
                         </goals>
                     </execution>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -135,7 +135,7 @@
                           <delete dir="target/classes/com/vaadin/prodbundle"
                                 includeemptydirs="true"/>
                           <!-- Move bundle files to vaadin-prod-bundle folder -->
-                          <delete dir="target/classes/META-INF"
+                          <delete dir="target/classes/META-INF/VAADIN"
                                 includeemptydirs="true"/>
                       </target>
                     </configuration>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -98,6 +98,27 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>change-prod-bundle-location</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/vaadin-prod-bundle</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.outputDirectory}/META-INF/VAADIN</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
@@ -110,7 +131,11 @@
                       <target>
                         <!-- Remove application class file, so as IT modules do not read @Theme annotations when
                              maven configures the classpath for multimodule projects -->
-                        <delete dir="target/classes/com/vaadin/prodbundle" includeemptydirs="true"></delete>
+                          <delete dir="target/classes/com/vaadin/prodbundle"
+                                includeemptydirs="true"/>
+                          <!-- Move bundle files to vaadin-prod-bundle folder -->
+                          <delete dir="target/classes/META-INF"
+                                includeemptydirs="true"/>
                       </target>
                     </configuration>
                   </execution>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -88,7 +88,8 @@
             </plugin>
             <plugin>
                 <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-maven-plugin</artifactId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${flow.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -96,6 +96,9 @@
                             <goal>prepare-frontend</goal>
                             <goal>build-frontend</goal>
                         </goals>
+                        <configuration>
+                            <optimizeBundle>false</optimizeBundle>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
@@ -38,6 +38,11 @@
             <artifactId>flow-gradle-plugin</artifactId>
             <version>${flow.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-prod-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
@@ -47,6 +47,11 @@
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-prod-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <!-- Needed for lambdas in Mojos -->

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -65,6 +65,11 @@
                 <artifactId>vaadin-dev-bundle</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-prod-bundle</artifactId>
+                <version>${project.version}</version>
+            </dependency>
             <!-- Flow -->
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -65,11 +65,6 @@
                 <artifactId>vaadin-dev-bundle</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-prod-bundle</artifactId>
-                <version>${project.version}</version>
-            </dependency>
             <!-- Flow -->
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -34,7 +34,6 @@
             <version>${project.version}</version>
         </dependency>
 
-
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -34,6 +34,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-prod-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -34,11 +34,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-prod-bundle</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
     </dependencies>
     <build>

--- a/vaadin-prod-bundle/frontend/themes/vaadin-prod-bundle/theme.json
+++ b/vaadin-prod-bundle/frontend/themes/vaadin-prod-bundle/theme.json
@@ -1,0 +1,3 @@
+{
+  "lumoImports": ["typography", "color", "spacing", "badge", "utility"]
+}

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -1,0 +1,16 @@
+package com.vaadin.prodbundle;
+
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.server.PWA;
+import com.vaadin.flow.theme.Theme;
+
+@Theme("vaadin-prod-bundle")
+@PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
+@JsModule("@vaadin-component-factory/vcf-nav")
+@NpmPackage(value = "line-awesome", version = "1.3.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
+public class FakeAppConf implements AppShellConfigurator{
+
+}

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -9,7 +9,6 @@ import com.vaadin.flow.theme.Theme;
 @Theme("vaadin-prod-bundle")
 @PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
 @JsModule("@vaadin-component-factory/vcf-nav")
-@NpmPackage(value = "line-awesome", version = "1.3.0")
 @NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
 public class FakeAppConf implements AppShellConfigurator{
 


### PR DESCRIPTION
This adds a standalone maven module for default prod bundle. The bundle is generated in a regular way with 'build-frontend' goal. Will be used by Flow in case if an app has no frontend add-ons.

Part-of https://github.com/vaadin/platform/issues/4046