### PR TITLE
feat: add `hilla-react-spring-boot-starter` module

### DIFF
--- a/hilla-react-spring-boot-starter/pom.xml
+++ b/hilla-react-spring-boot-starter/pom.xml
@@ -9,9 +9,9 @@
     </parent>
 
     <groupId>dev.hilla</groupId>
-    <artifactId>hilla-spring-boot-starter</artifactId>
-    <name>Hilla Spring Boot Starter</name>
-    <description>Spring Boot Starter for Hilla applications using Lit.</description>
+    <artifactId>hilla-react-spring-boot-starter</artifactId>
+    <name>Hilla-React Spring Boot Starter</name>
+    <description>Spring Boot Starter for Hilla applications using React.</description>
     <version>${hilla.version}</version>
 
     <repositories>
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>dev.hilla</groupId>
-            <artifactId>hilla</artifactId>
+            <artifactId>hilla-react</artifactId>
         </dependency>
 
         <!-- Spring -->

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
                 <module>hilla-dev</module>
                 <module>hilla-react</module>
                 <module>hilla-spring-boot-starter</module>
+                <module>hilla-react-spring-boot-starter</module>
                 <module>hilla-maven-plugin</module>
             </modules>
         </profile>

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -69,6 +69,11 @@
                 <artifactId>hilla-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>dev.hilla</groupId>
+                <artifactId>hilla-react-spring-boot-starter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
Closes #4027.

If this PR is OK, then the direct dependency from `dev.hilla:hilla` or `dev.hilla:hilla-react` could be removed in Start projects.