### PR TITLE
chore: adjust transitive flow-server dependency in quarkus extension

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -472,7 +472,7 @@ async function main() {
     await run('mvn -ntp -B org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom -q');
     await run('npm ls --depth 6 --omit dev', { output: 'target/tree-npm.txt' });
     await run('npm install');
-    await run('npm install @cyclonedx/cyclonedx-npm');
+    await run('npm install --save-dev @cyclonedx/cyclonedx-npm');
     await run('npx @cyclonedx/cyclonedx-npm --omit dev --output-file target/bom-npm.json --output-format JSON');
   }
 

--- a/vaadin-quarkus-extension/pom.xml
+++ b/vaadin-quarkus-extension/pom.xml
@@ -48,6 +48,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-quarkus</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-server</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Description

The 'vaadin-quarkus' artifact, defined in 'vaadin-quarkus-extension', has a compile scoped dependency to 'flow-server', whose version is fixed during the Vaadin Quarkus add-on release.
When resolving transitive dependencies, Maven picks the 'nearest definition', so in an application project, the 'flow-version' pinned in 'vaadin-quarkus' takes precedence over the one defined by the platform ('vaadin-core'). To get the correct version the application project needs to also import the Vaadin BOM.
Adding the exclusion of 'flow-server' in 'vaadin-quarkus' allows to use 'vaadin-quarkus-extension' in an application project without importing the platform BOM.
## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
