### PR TITLE
chore: add metadata to vaadin-quarkus-extension

### DIFF
--- a/vaadin-quarkus-extension/pom.xml
+++ b/vaadin-quarkus-extension/pom.xml
@@ -58,4 +58,30 @@
             <artifactId>vaadin-core-jandex</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-extension-metadata</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.vaadin</includeGroupIds>
+                            <includeArtifactIds>vaadin-quarkus</includeArtifactIds>
+                            <includeTypes>jar</includeTypes>
+                            <excludeClassifiers>codestarts</excludeClassifiers>
+                            <includes>META-INF/quarkus-extension.yaml</includes>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
The vaadin-quarkus extension artifact is not enough to create a new Vaadin based Quarkus application, as it only depends on flow-server, and it misses jandex index and Vaadin components.
To better integrate with Quarkus tooling, this artifact should be registered within the Quarkus egistry, but it has to contain the Quarkus metadata file that is present in the vaadin-quarkus artifact.
