### PR TITLE
chore!: Remove external modules from dev and prod bundle

### DIFF
--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
@@ -1,7 +1,5 @@
 package com.vaadin.devbundle;
 
-import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;

--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
@@ -8,7 +8,6 @@ import com.vaadin.flow.theme.Theme;
 
 @Theme("vaadin-dev-bundle")
 @PWA(name = "vaadin-dev-bundle", shortName = "vaadin-dev-bundle")
-@JsModule("@vaadin-component-factory/vcf-nav")
 public class FakeAppConf implements AppShellConfigurator{
 
 }

--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeAppConf.java
@@ -9,8 +9,6 @@ import com.vaadin.flow.theme.Theme;
 @Theme("vaadin-dev-bundle")
 @PWA(name = "vaadin-dev-bundle", shortName = "vaadin-dev-bundle")
 @JsModule("@vaadin-component-factory/vcf-nav")
-@NpmPackage(value = "line-awesome", version = "1.3.0")
-@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
 public class FakeAppConf implements AppShellConfigurator{
 
 }

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -1,7 +1,5 @@
 package com.vaadin.prodbundle;
 
-import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -8,8 +8,6 @@ import com.vaadin.flow.theme.Theme;
 
 @Theme("vaadin-prod-bundle")
 @PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
-@JsModule("@vaadin-component-factory/vcf-nav")
-@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
 public class FakeAppConf implements AppShellConfigurator{
 
 }


### PR DESCRIPTION
Having external dependencies without a managed the version makes it impossible to upgrade those dependencies. We already remove used of line-awesome as an npm dependency in 24.0 and vcf-nav is being replaced in 24.1 with `vaadin-side-nav`
