### PR TITLE
chore: bump MPR to 5.1.0.alpha1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -166,10 +166,10 @@
             "npmName": "@vaadin/message-list"
         },
         "mpr-v7": {
-            "javaVersion": "5.0.11"
+            "javaVersion": "5.1.0.alpha1"
         },
         "mpr-v8": {
-            "javaVersion": "5.0.11"
+            "javaVersion": "5.1.0.alpha1"
         },
         "notification": {
             "jsVersion": "22.1.0-alpha1",


### PR DESCRIPTION
 bump MPR to `5.1.0.alpha1` in `versions.json` for the 22.1 branch.

Relevant release notes:
- https://github.com/vaadin/multiplatform-runtime-internal/releases/tag/5.1.0.alpha1