### PR TITLE
fix: Change vaadin iconset to be lazy loaded

### DIFF
--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
@@ -91,7 +91,6 @@ public class EagerView extends Div {
     public GridPro<String> gridPro;
     public HorizontalLayout horizontalLayout;
     public IntegerField integerField;
-    public Icon icon;
     public ListBox<String> listBox;
     public LoginOverlay loginOverlay;
     public LoginForm LoginForm;

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/IconView.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/IconView.java
@@ -1,0 +1,16 @@
+package com.vaadin.prodbundle;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.internal.DependencyTrigger;
+
+@Route
+@DependencyTrigger(Icon.class)
+public class IconView extends Div {
+
+    public IconView() {
+        add(new Icon());
+    }
+
+}


### PR DESCRIPTION
Reduces the size of the intial bundle from 1.3MB to 1.0MB (uncompressed)
