### PR TITLE
chore: Add dev bundle to vaadin-maven-plugin

### DIFF
--- a/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-gradle-plugin-pom.xml
@@ -43,6 +43,13 @@
             <artifactId>vaadin-prod-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Dev bundle is needed to copy package-lock file from it to the project, -->
+        <!-- this speeds up the production bundle build -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
@@ -52,6 +52,13 @@
             <artifactId>vaadin-prod-bundle</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Dev bundle is needed to copy package-lock file from it to the project, -->
+        <!-- this speeds up the production bundle build -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-bundle</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <!-- Needed for lambdas in Mojos -->


### PR DESCRIPTION
If a project doesn't have a lock file and vaadin-dev is excluded from the dependencies, Flow regenerates the lock file, which takes time. This patch add dev bundle to the Vaadin plugin, so Flow can find it and copy lock file from there.

Fixes https://github.com/vaadin/flow/issues/16041