### PR TITLE
chore: Add supported browsers to tests

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -26,7 +26,8 @@ public class ComponentsIT extends AbstractPlatformTest {
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             String browsers = System.getProperty("grid.browsers");
             if (browsers == null || browsers.isEmpty()) {
-                Parameters.setGridBrowsers("firefox,safari,edge");
+                // supported broswers : firefox esr is 102, safari 15 is listed in the note
+                Parameters.setGridBrowsers("firefox,firefox-102,safari,safari-15,edge");
             } else {
                 Parameters.setGridBrowsers(browsers);
             }

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -26,8 +26,8 @@ public class ComponentsIT extends AbstractPlatformTest {
         if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
             String browsers = System.getProperty("grid.browsers");
             if (browsers == null || browsers.isEmpty()) {
-                // supported broswers : firefox esr is 102, safari 15 is listed in the note
-                Parameters.setGridBrowsers("firefox,firefox-102,safari,safari-15,edge");
+                // supported broswers : firefox esr is 102
+                Parameters.setGridBrowsers("firefox,firefox-102,safari,edge");
             } else {
                 Parameters.setGridBrowsers(browsers);
             }


### PR DESCRIPTION
safari 15 and firefox esr have been listed in the note as supported browsers.

saucelabs is using safari 15.1 as testing browser. but the feature, `csslayerblockrule`,  we depends on is from safari 15.4 