### PR TITLE
chore: remove the unnecessary body content with asset upload [skip ci]

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -124,7 +124,6 @@ jobs:
           asset_name: "Software.Bill.Of.Materials.json"
           tag: ${{ github.event.inputs.version || github.event.release.tag_name }}
           overwrite: true
-          body: "Vaadin Platform V${{github.event.inputs.version}} SBOM"
       - if: ${{(success() || github.event.inputs.forcePushReports) && (github.event.inputs.version || github.event.release.tag_name)}}
         uses: svenstaro/upload-release-action@v2
         with:
@@ -133,5 +132,4 @@ jobs:
           asset_name: "Dependencies.Report.html"
           tag: ${{ github.event.inputs.version || github.event.release.tag_name }}
           overwrite: true
-          body: "Vaadin Platform V${{github.event.inputs.version}} Dependencies"
 


### PR DESCRIPTION
starting from 2.6.1, the plugin checks the body variable for overwriting the release note content. 
let us remove them as it is not necessary. 

tested with platform 23.3.13 release. 