### PR TITLE
chore: group platform modules in a profile, remove gradle module activation rule

### DIFF
--- a/hilla-dev/pom.xml
+++ b/hilla-dev/pom.xml
@@ -14,6 +14,9 @@
     <description>Hilla Platform Development Dependencies</description>
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>    
     <distributionManagement>
         <repository>
             <id>vaadin-prereleases</id>

--- a/hilla-dev/pom.xml
+++ b/hilla-dev/pom.xml
@@ -15,7 +15,7 @@
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>    
     <distributionManagement>
         <repository>

--- a/hilla-react-spring-boot-starter/pom.xml
+++ b/hilla-react-spring-boot-starter/pom.xml
@@ -14,7 +14,7 @@
     <description>Spring Boot Starter for Hilla applications using React.</description>
     <version>${hilla.version}</version>
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->

--- a/hilla-react-spring-boot-starter/pom.xml
+++ b/hilla-react-spring-boot-starter/pom.xml
@@ -13,7 +13,9 @@
     <name>Hilla-React Spring Boot Starter</name>
     <description>Spring Boot Starter for Hilla applications using React.</description>
     <version>${hilla.version}</version>
-
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
 

--- a/hilla-react/pom.xml
+++ b/hilla-react/pom.xml
@@ -15,7 +15,7 @@
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>    
     <distributionManagement>
         <repository>

--- a/hilla-react/pom.xml
+++ b/hilla-react/pom.xml
@@ -14,6 +14,9 @@
     <description>Hilla Platform for React-based Applications</description>
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>    
     <distributionManagement>
         <repository>
             <id>vaadin-prereleases</id>

--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -14,7 +14,7 @@
     <description>Spring Boot Starter for Hilla applications using Lit.</description>
     <version>${hilla.version}</version>
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->

--- a/hilla-spring-boot-starter/pom.xml
+++ b/hilla-spring-boot-starter/pom.xml
@@ -13,7 +13,9 @@
     <name>Hilla Spring Boot Starter</name>
     <description>Spring Boot Starter for Hilla applications using Lit.</description>
     <version>${hilla.version}</version>
-
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
     <repositories>
         <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
 

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -15,7 +15,7 @@
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
     <properties>
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>
     <distributionManagement>
         <repository>

--- a/hilla/pom.xml
+++ b/hilla/pom.xml
@@ -14,6 +14,9 @@
     <description>Hilla Platform</description>
     <version>${hilla.version}</version>
     <url>https://hilla.dev</url>
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
     <distributionManagement>
         <repository>
             <id>vaadin-prereleases</id>

--- a/pom.xml
+++ b/pom.xml
@@ -31,25 +31,34 @@
         </repository>
     </distributionManagement>
 
-    <modules>
-        <module>vaadin-internal</module>
-        <module>vaadin</module>
-        <module>vaadin-spring-bom</module>
-        <module>vaadin-bom</module>
-        <module>vaadin-core-internal</module>
-        <module>vaadin-core</module>
-        <module>vaadin-dev</module>
-        <module>vaadin-maven-plugin</module>
-        <module>vaadin-testbench</module>
-        <module>vaadin-testbench-junit5</module>
-        <module>vaadin-spring-boot-starter</module>
-        <module>vaadin-platform-javadoc</module>
-        <module>vaadin-dev-bundle</module>
-        <module>vaadin-prod-bundle/pom-unoptimized.xml</module>
-        <module>vaadin-prod-bundle</module>
-    </modules>
+
 
     <profiles>
+        <profile>
+            <id>platform</id>
+            <activation>
+                <property>
+                    <name>!skipPlatform</name>
+                </property>
+            </activation>
+            <modules>
+                <module>vaadin-internal</module>
+                <module>vaadin</module>
+                <module>vaadin-spring-bom</module>
+                <module>vaadin-bom</module>
+                <module>vaadin-core-internal</module>
+                <module>vaadin-core</module>
+                <module>vaadin-dev</module>
+                <module>vaadin-maven-plugin</module>
+                <module>vaadin-testbench</module>
+                <module>vaadin-testbench-junit5</module>
+                <module>vaadin-spring-boot-starter</module>
+                <module>vaadin-platform-javadoc</module>
+                <module>vaadin-dev-bundle</module>
+                <module>vaadin-prod-bundle/pom-unoptimized.xml</module>
+                <module>vaadin-prod-bundle</module>
+            </modules>
+        </profile>    
         <profile>
             <id>sbom</id>
             <modules>
@@ -58,9 +67,6 @@
         </profile>
         <profile>
             <id>gradle</id>
-            <activation>
-                <jdk>(,18)</jdk>
-            </activation>
             <modules>
                 <module>vaadin-gradle-plugin</module>
                 <module>vaadin-gradle-plugin/pom-portal.xml</module>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,45 @@
 
     <profiles>
         <profile>
+            <id>sbom</id>
+            <modules>
+                <module>vaadin-platform-sbom</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>gradle</id>
+            <modules>
+                <module>vaadin-gradle-plugin</module>
+                <module>vaadin-gradle-plugin/pom-portal.xml</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jandex</id>
+            <modules>
+                <module>vaadin-jandex</module>
+                <module>vaadin-core-jandex</module>
+                <module>vaadin-quarkus-extension</module>
+            </modules>
+        </profile>
+        <!-- separate hilla related modules for releases -->
+        <profile>
+            <id>hilla</id>
+            <modules>
+                <module>hilla-bom</module>
+                <module>hilla</module>
+                <module>hilla-dev</module>
+                <module>hilla-react</module>
+                <module>hilla-spring-boot-starter</module>
+                <module>hilla-react-spring-boot-starter</module>
+            </modules>
+            <!-- This prevents deploying all com.vaadin modules, but we need to set it to true in
+            all hilla modules  -->
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+        <!-- separate platform modules for active by default it must be after hilla modules -->
+        <profile>
             <id>platform</id>
             <activation>
                 <property>
@@ -58,39 +97,9 @@
                 <module>vaadin-prod-bundle/pom-unoptimized.xml</module>
                 <module>vaadin-prod-bundle</module>
             </modules>
-        </profile>    
-        <profile>
-            <id>sbom</id>
-            <modules>
-                <module>vaadin-platform-sbom</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>gradle</id>
-            <modules>
-                <module>vaadin-gradle-plugin</module>
-                <module>vaadin-gradle-plugin/pom-portal.xml</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>jandex</id>
-            <modules>
-                <module>vaadin-jandex</module>
-                <module>vaadin-core-jandex</module>
-                <module>vaadin-quarkus-extension</module>
-            </modules>
-        </profile>
-        <!-- separate hilla related moduels for releases -->
-        <profile>
-            <id>hilla</id>
-            <modules>
-                <module>hilla-bom</module>
-                <module>hilla</module>
-                <module>hilla-dev</module>
-                <module>hilla-react</module>
-                <module>hilla-spring-boot-starter</module>
-                <module>hilla-react-spring-boot-starter</module>
-            </modules>
+            <properties>
+                <maven.deploy.skip>false</maven.deploy.skip>
+            </properties>
         </profile>
         <!-- Needed so as we can skip this module on releasing and still nexus stating works -->
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
             <!-- This prevents deploying all com.vaadin modules, but we need to set it to true in
             all hilla modules  -->
             <properties>
-                <maven.deploy.skip>true</maven.deploy.skip>
+                <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
             </properties>
         </profile>
         <!-- separate platform modules for active by default it must be after hilla modules -->
@@ -98,7 +98,7 @@
                 <module>vaadin-prod-bundle</module>
             </modules>
             <properties>
-                <maven.deploy.skip>false</maven.deploy.skip>
+                <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
             </properties>
         </profile>
         <!-- Needed so as we can skip this module on releasing and still nexus stating works -->

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -16,6 +16,7 @@
 	
     <properties>
         {{javadeps}}
+        <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
 
     <distributionManagement>

--- a/scripts/generator/templates/template-hilla-bom.xml
+++ b/scripts/generator/templates/template-hilla-bom.xml
@@ -16,7 +16,7 @@
 	
     <properties>
         {{javadeps}}
-        <maven.deploy.skip>false</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>false</skipNexusStagingDeployMojo>
     </properties>
 
     <distributionManagement>

--- a/scripts/generator/templates/template-servlet-containers-tests-pom.xml
+++ b/scripts/generator/templates/template-servlet-containers-tests-pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <!-- this version is needed for app.bndrun file -->
         {{javadeps}}
     </properties>

--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <maven.deploy.skip>true</maven.deploy.skip>
+        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
         <osgi.bundle.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</osgi.bundle.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
this will simplify the hilla release build by calling the `hilla` profile instead of using `-pl`