### PR TITLE
chore: upgrade sb to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <hilla.version>2.2-SNAPSHOT</hilla.version>
-        <spring.boot.version>3.1.0</spring.boot.version>
+        <spring.boot.version>3.1.1</spring.boot.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <jetty.version>11.0.13</jetty.version>
     </properties>


### PR DESCRIPTION
this will resolve the CVE reported on `spring-boot-web` dependency which depends on `tomcat-embed-core` https://nvd.nist.gov/vuln/detail/CVE-2023-34981

