### PR TITLE
chore: update flow to 24.0.11 and spring.boot to 3.0.8 (24.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <hilla.version>2.0-SNAPSHOT</hilla.version>
-        <spring.boot.version>3.0.7</spring.boot.version>
+        <spring.boot.version>3.0.8</spring.boot.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <jetty.version>11.0.13</jetty.version>
     </properties>

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -43,6 +43,8 @@ const licenseWhiteList = [
 const cveWhiteList = {
   // Check fix in vaadin-testbench/pom.xml, and update when Selenium is fixed
   // 'pkg:maven/com.google.guava/guava@31.1-jre': ['CVE-2020-8908', 'CVE-2023-2976']
+  // based on the issue this is not a CVE https://github.com/FasterXML/jackson-databind/issues/3972
+  'pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.2' : ['CVE-2023-35116']
 }
 
 const STYLE = `<style>

--- a/versions.json
+++ b/versions.json
@@ -98,7 +98,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.0.10"
+            "javaVersion": "24.0.11"
         },
         "flow-cdi": {
             "javaVersion": "15.0.0"


### PR DESCRIPTION
this will resolve the CVE reported on spring-boot-web dependency which depends on tomcat-embed-core https://nvd.nist.gov/vuln/detail/CVE-2023-34981
