### PR TITLE
chore: remove not needed imports

### DIFF
--- a/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
+++ b/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
@@ -52,7 +52,6 @@ import '@vaadin/progress-bar';
 import '@vaadin/radio-group';
 import '@vaadin/rich-text-editor';
 import '@vaadin/scroller/vaadin-scroller';
-import '@vaadin/side-nav/enable.js';
 import '@vaadin/side-nav';
 import '@vaadin/side-nav/vaadin-side-nav-item.js';
 import '@vaadin/split-layout';


### PR DESCRIPTION
this class has been removed in the latest side-nav release