### PR TITLE
chore: provide spring-boot-devtool to javadoc generation [skip ci]

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -90,6 +90,11 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-devtools</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.springframework.security</groupId>
                     <artifactId>spring-security-core</artifactId>
                     <scope>provided</scope>


### PR DESCRIPTION
new dependency has been added on flow side https://github.com/vaadin/flow/commit/349cc1105a1e5901863ddd210120ff3606490e47#diff-634e85ae9a7dd3ca2d705273509f0a294cbd424c616316f8b78aa7b6eb7eba41

currently platform javadoc generation step has failed. 

