### PR TITLE
remove outdated tomcat exclusions

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -65,26 +65,7 @@
                     <groupId>org.yaml</groupId>
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.tomcat.embed</groupId>
-                    <artifactId>tomcat-embed-websocket</artifactId>
-                </exclusion>
             </exclusions>
-        </dependency>
-        <!-- CVE-2023-41080 UNTIL new Springboot with tomcat version bump -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>10.1.13</version>
         </dependency>
         <!-- End Spring -->
     </dependencies>


### PR DESCRIPTION
in spring-boot 3.1.4, the integrated version of tomcat-core is 10.1.13, so that the version overwrite is not necessary any more

