### PR TITLE
fix: copy dev bundle files from correct place

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -119,7 +119,7 @@
                             <outputDirectory>${project.build.outputDirectory}/vaadin-dev-bundle</outputDirectory>
                             <resources>
                                 <resource>
-                                    <directory>src/main/dev-bundle</directory>
+                                    <directory>${project.build.directory}/dev-bundle</directory>
                                 </resource>
                             </resources>
                         </configuration>

--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -132,7 +132,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>${project.basedir}/src/main/dev-bundle</directory>
+                            <directory>${project.basedir}/src/main/bundles</directory>
                         </fileset>
                     </filesets>
                 </configuration>

--- a/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
+++ b/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
@@ -49,6 +49,6 @@ public class BundleTest {
             }
 
         });
-        Assertions.assertEquals(1, foundInFiles.get(), "The key '" + needle + "'' should be found in one file");
+        Assertions.assertEquals(1, foundInFiles.get(), "The key '" + needle + "' should be found in one file");
     }
 }

--- a/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
+++ b/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
@@ -19,7 +19,7 @@ public class BundleTest {
     @Test
     public void usageStatsIncluded() throws IOException {
         String needle = "StatisticsGatherer";
-        Path bundlerBuildFolder = Paths.get("src", "main", "dev-bundle", "webapp", "VAADIN", "build");
+        Path bundlerBuildFolder = Paths.get("target", "dev-bundle", "webapp", "VAADIN", "build");
         AtomicInteger foundInFiles = new AtomicInteger();
         Files.walkFileTree(bundlerBuildFolder, new FileVisitor<Path>() {
 

--- a/vaadin-platform-test/pom-dev.xml
+++ b/vaadin-platform-test/pom-dev.xml
@@ -173,7 +173,7 @@
                               <target>
                                 <!-- Express mode does not need any frontend stuff -->
                                 <delete dir="node_modules" includeemptydirs="true"></delete>
-                                <delete dir="src/main/dev-bundle" includeemptydirs="true"></delete>
+                                <delete dir="src/main/bundles" includeemptydirs="true"></delete>
                                 <delete file="package.json"></delete>
                                 <delete file="package-lock.json"></delete>
                                 <delete file="tsconfig.json"></delete>

--- a/vaadin-platform-test/pom-dev.xml
+++ b/vaadin-platform-test/pom-dev.xml
@@ -174,6 +174,7 @@
                                 <!-- Express mode does not need any frontend stuff -->
                                 <delete dir="node_modules" includeemptydirs="true"></delete>
                                 <delete dir="src/main/bundles" includeemptydirs="true"></delete>
+                                <delete dir="${project.build.directory}/dev-bundle" includeemptydirs="true"></delete>
                                 <delete file="package.json"></delete>
                                 <delete file="package-lock.json"></delete>
                                 <delete file="tsconfig.json"></delete>

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
@@ -29,7 +29,7 @@ public class DefaultDevBundleIT extends AbstractPlatformTest {
     @Test
     public void test() throws Exception {
         File baseDir = new File(System.getProperty("user.dir", "."));
-        File devBundle = new File(baseDir, Constants.DEV_BUNDLE_LOCATION);
+        File devBundle = new File(baseDir, "target/" + Constants.DEV_BUNDLE_LOCATION);
         File nodeModules = new File(baseDir, FrontendUtils.NODE_MODULES);
 
         // shouldn't create a dev-bundle

--- a/versions.json
+++ b/versions.json
@@ -102,7 +102,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.3.0.alpha3"
+            "javaVersion": "24.3-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "15.0.1"


### PR DESCRIPTION
The package feature for devBundle
moves the dev bundle files to a
new folder. Copy from new folder
when generating jar.


Depends on vaadin/flow#17977