### PR TITLE
fix: Add DnD Connector to prod bundle

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -48,6 +48,7 @@ const licenseWhiteList = [
 ];
 
 const cveWhiteList = {
+  'pkg:maven/com.vaadin.flow.ai/form-filler-addon@1.0.1': ['CVE-2019-25027', 'CVE-2021-31412', 'CVE-2018-25007', 'CVE-2021-31404']
 }
 
 const STYLE = `<style>

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -1,5 +1,7 @@
 package com.vaadin.prodbundle;
 
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.PWA;
@@ -8,6 +10,7 @@ import com.vaadin.flow.theme.Theme;
 @Theme("vaadin-prod-bundle")
 @PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
 @LoadDependenciesOnStartup(EagerView.class)
+@JsModule(DndUtil.DND_CONNECTOR)  
 public class FakeAppConf implements AppShellConfigurator {
 
 }

--- a/versions.json
+++ b/versions.json
@@ -102,7 +102,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.3.0.alpha4"
+            "javaVersion": "24.3.0.alpha5"
         },
         "flow-cdi": {
             "javaVersion": "15.0.1"

--- a/versions.json
+++ b/versions.json
@@ -102,7 +102,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.3.0.alpha5"
+            "javaVersion": "24.3-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "15.0.1"


### PR DESCRIPTION
Imports `dndConnector.js` to the prod bundle, as now there is nothing that triggers this import - DragSource and DragTarget were removed from Grid, see https://github.com/vaadin/flow-components/pull/5686.