### PR TITLE
chore:fix gradle release issue

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -24,18 +24,6 @@
         {{javadeps}}
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -46,9 +34,9 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spreadsheet-flow</artifactId>
+            <version>{{platform}}</version>
             <optional>true</optional>
         </dependency>
-
 
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -25,18 +25,6 @@
       <skipTests>false</skipTests>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -47,6 +35,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spreadsheet-flow</artifactId>
+            <version>{{platform}}</version>
             <optional>true</optional>
         </dependency>
 

--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -55,6 +55,7 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
  **********************************************************************************************************************/
 
 repositories {
+    mavenLocal()
     maven { url 'target/dependencies' }
     maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
     mavenCentral()


### PR DESCRIPTION
this PR fix the issue with gradle release. 

add `mavenLocal()` repository to **build.gradle** , which let the plugin module to find the dev-bundle/prod-bundle with new versions. 

maven has it own reactor for build modules, which defines the order of all modules. `vaadin-bom` is coming after bundle modules. so it fails the build with cannot find bom modules in the build log.  