### PR TITLE
fix: add missing vaadin-overlay npm package version (23.3)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -189,6 +189,10 @@
             "jsVersion": "23.3.28",
             "npmName": "@vaadin/number-field"
         },
+        "overlay": {
+            "jsVersion": "23.3.28",
+            "npmName": "@vaadin/overlay"
+        },
         "password-field": {
             "jsVersion": "23.3.28",
             "npmName": "@vaadin/password-field"


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/flow/issues/18149

We missed to add `@vaadin/overlay` to `versions.json` for Vaadin 23, which prevents PNPM from locking it properly.

## Type of change

- Bugfix