### PR TITLE
chore: remove extra wait for dev spinner

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ChromeComponentsIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.platform.test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.BufferedWriter;
@@ -24,7 +23,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -85,16 +83,6 @@ public class ChromeComponentsIT extends AbstractPlatformTest {
 
     @Before
     public void load(){
-        waitUntil(driver -> {
-            try {
-                TestBenchElement testBenchElement = $("div").attribute("class", "message").waitForFirst();
-                return testBenchElement == null;
-            } catch (TimeoutException e){
-                return true;
-            } catch (NoSuchElementException e){
-                return true;
-            }
-        });
         $(NotificationElement.class).waitForFirst();
     }
 

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import com.vaadin.flow.component.confirmdialog.testbench.ConfirmDialogElement;
 import org.junit.Test;
@@ -19,8 +18,6 @@ import com.vaadin.testbench.ElementQuery;
 import com.vaadin.testbench.Parameters;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.parallel.SauceLabsIntegration;
-import org.openqa.selenium.TimeoutException;
-
 
 public class ComponentsIT extends AbstractPlatformTest {
 
@@ -65,17 +62,6 @@ public class ComponentsIT extends AbstractPlatformTest {
 
     @Test
     public void appWorks() throws Exception {
-        waitUntil(driver -> {
-            try {
-                TestBenchElement testBenchElement = $("div").attribute("class", "message").waitForFirst();
-                return testBenchElement == null;
-            } catch (TimeoutException e){
-                return true;
-            } catch (NoSuchElementException e){
-                return true;
-            }
-        });
-
         $(NotificationElement.class).waitForFirst();
 
         new ComponentUsageTest().getTestComponents().forEach(this::checkElement);


### PR DESCRIPTION
in TB 9.2.0, the wait for spinner has been integrated in the `waitForVaadin()` method. 