### PR TITLE
test: run with vaadin-router

### DIFF
--- a/vaadin-platform-hybrid-test/pom-dev-mode.xml
+++ b/vaadin-platform-hybrid-test/pom-dev-mode.xml
@@ -247,6 +247,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <reactRouterEnabled>false</reactRouterEnabled>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>

--- a/vaadin-platform-hybrid-test/pom.xml
+++ b/vaadin-platform-hybrid-test/pom.xml
@@ -180,6 +180,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <reactRouterEnabled>false</reactRouterEnabled>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Run the hybrid test module using vaadin-router instead of react-router as it specifically imports vaadin-router