### PR TITLE
chore: vaadin-spring-boot-starter should bring the hilla-react by default instead of hilla

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin.hilla</groupId>
-            <artifactId>hilla</artifactId>
+            <artifactId>hilla-react</artifactId>
         </dependency>
 
         <!-- Spring -->


### PR DESCRIPTION

User needs to exclude hilla-react and add hilla if they want to use hilla-lit instead of hilla-react

