### PR TITLE
fix: include React components with npm install in -sbom

### DIFF
--- a/vaadin-platform-sbom/pom.xml
+++ b/vaadin-platform-sbom/pom.xml
@@ -108,6 +108,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <reactRouterEnabled>true</reactRouterEnabled>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
closes #4986

Alternative cleaner solution to fix npm install error.