### PR TITLE
chore: remove temporary exclusion in spring-boot-starter

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -56,12 +56,6 @@
         <dependency>
             <groupId>com.vaadin.hilla</groupId>
             <artifactId>hilla-react</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.vaadin.hilla</groupId>
-                    <artifactId>hilla-dev-mode</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Spring -->


### PR DESCRIPTION
hilla and hilla-react do not have the hilla-dev dependency anymor