### PR TITLE
chore: Remove Copilot from 24.3

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -43,11 +43,6 @@
             <artifactId>vaadin-dev-server</artifactId>
             <version>${flow.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>copilot</artifactId>
-            <version>${copilot.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -151,11 +151,6 @@
                 <artifactId>vaadin-spring-boot-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>copilot</artifactId>
-                <version>${copilot.version}</version>
-            </dependency>
 
             <!-- Free Components -->
             <dependency>

--- a/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
+++ b/vaadin-dev-bundle/src/test/java/com/vaadin/devbundle/BundleTest.java
@@ -26,16 +26,6 @@ public class BundleTest {
         Assertions.assertEquals(1, foundInFiles,
                 "The key '" + needle + "' should be found in one file");
     }
-    @Test
-    public void copilotIncluded() throws IOException {
-        String needle = "copilot-main";
-        Path bundlerBuildFolder = Paths.get("target", "dev-bundle", "webapp",
-                "VAADIN", "build");
-
-        int foundInFiles = findInFiles(bundlerBuildFolder, needle);
-        Assertions.assertEquals(1, foundInFiles,
-                "The key '" + needle + "' should be found in one file");
-    }
 
     private int findInFiles(Path path, String needle) throws IOException {
         AtomicInteger foundInFiles = new AtomicInteger();

--- a/vaadin-dev/pom.xml
+++ b/vaadin-dev/pom.xml
@@ -44,11 +44,6 @@
             <artifactId>vaadin-dev-bundle</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>copilot</artifactId>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/vaadin-platform-sbom/pom.xml
+++ b/vaadin-platform-sbom/pom.xml
@@ -86,10 +86,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-swing-kit-client-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>copilot</artifactId>
-        </dependency>
 
     </dependencies>
     <profiles>

--- a/versions.json
+++ b/versions.json
@@ -322,9 +322,6 @@
         "azure-kit": {
             "version": "1.0.0"
         },
-        "copilot": {
-            "javaVersion": "24.3.11"
-        },
         "kubernetes-kit-starter": {
             "javaVersion": "2.2.0"
         },


### PR DESCRIPTION
We will no longer update Copilot for 24.3 so we will remove it to avoid later compatibility problems