### PR TITLE
chore: get rid of GHA warning of using Node 16 [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -114,14 +114,14 @@ jobs:
       - uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: stable
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: stCarolas/setup-maven@v4.5
+      - uses: stCarolas/setup-maven@v5
         with:
           maven-version: '3.9.0'
       - run: |

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -51,20 +51,20 @@ jobs:
             && echo "🚫 **TB_LICENSE** is not defined, check that **${{github.repository}}** repo has a valid secret" \
             | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
         name: Check secrets
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-      - uses: stCarolas/setup-maven@v4.5
+      - uses: stCarolas/setup-maven@v5
         with:
           maven-version: '3.8.2'
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
       - run: go install github.com/google/osv-scanner/cmd/osv-scanner@v1
@@ -105,7 +105,7 @@ jobs:
           message: "${{env.DEPENDENCIES_REPORT}}\n[[Click for more Details](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})]"
           comment_tag: dependencies_report
       - if: ${{always()}}
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@v4
         with:
           name: files
           path: |


### PR DESCRIPTION
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3, actions/setup-java@v3, stCarolas/setup-maven@v4.5, actions/upload-artifact@v3.1.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```