### PR TITLE
refactor: replace hilla-react with hilla

### DIFF
--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin.hilla</groupId>
-            <artifactId>hilla-react</artifactId>
+            <artifactId>hilla</artifactId>
         </dependency>
 
         <!-- Spring -->


### PR DESCRIPTION
Since `hilla` and `hilla-react` have the same content after recent changes, keeping both is redundant.

If we would like to remove one of them, it would make sense to keep only `hilla`, the one with a shorter and simpler name.
