### PR TITLE
remove deprecated configuration [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,6 @@
                     <version>3.3.1</version>
                     <configuration>
                         <includeDependencySources>true</includeDependencySources>
-                        <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                         <dependencySourceExcludes>
                             <!-- Exclude client engine since it is not user
                                 facing API -->

--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -184,7 +184,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <id>javadoc-jar</id>


### PR DESCRIPTION
this `<includeTransitiveDependencySources>` has been deprecated in maven-javadoc-plugin. 
