### PR TITLE
chore: exclude hilla-parse and hilla-runtime package for javadoc [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,11 +186,14 @@
                     <version>3.3.1</version>
                     <configuration>
                         <includeDependencySources>true</includeDependencySources>
+                        <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
                         <dependencySourceExcludes>
                             <!-- Exclude client engine since it is not user
                                 facing API -->
                             <dependencySourceExclude>com.vaadin:flow-client</dependencySourceExclude>
                             <dependencySourceExclude>com.vaadin:license-checker</dependencySourceExclude>
+                            <dependencySourceExclude>com.vaadin:hilla-parser*</dependencySourceExclude>
+                            <dependencySourceExclude>com.vaadin:hilla-runtime*</dependencySourceExclude>
                         </dependencySourceExcludes>
                         <dependencySourceIncludes>
                             <dependencySourceInclude>com.vaadin:*</dependencySourceInclude>

--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -150,6 +150,16 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
+                    <groupId>org.springframework.data</groupId>
+                    <artifactId>spring-data-jpa</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-data-jpa</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
                     <version>${junit.jupiter.version}</version>
@@ -177,6 +187,12 @@
                     <groupId>jakarta.annotation</groupId>
                     <artifactId>jakarta.annotation-api</artifactId>
                     <version>2.1.1</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hotswapagent</groupId>
+                    <artifactId>hotswap-agent</artifactId>
+                    <version>1.4.1</version>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
related with: https://github.com/vaadin/hilla/issues/2091