### PR TITLE
fix: Remove non-components deps from exclusion list

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -409,7 +409,6 @@
             "mode": "react",
             "npmName": "@vaadin/react-components",
             "exclusions": [
-                "@vaadin/a11y-base",
                 "@vaadin/accordion",
                 "@vaadin/app-layout",
                 "@vaadin/avatar",
@@ -467,9 +466,6 @@
                 "@vaadin/time-picker",
                 "@vaadin/tooltip",
                 "@vaadin/upload",
-                "@vaadin/vaadin-lumo-styles",
-                "@vaadin/vaadin-material-styles",
-                "@vaadin/vaadin-themable-mixin",
                 "@vaadin/vertical-layout",
                 "@vaadin/virtual-list"
             ]


### PR DESCRIPTION
These mixins, when excluded, are installed into `node_modules`, but the overall theming is broken and the lumo styles are not applied to UI:

<img width="192" alt="Screenshot 2024-02-27 at 12 11 01" src="https://github.com/vaadin/platform/assets/61410877/a3e04e5f-3f5b-45e4-8c6c-32276458169b">
