### PR TITLE
test: re-enable tests checking usage of bundle

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/DefaultDevBundleIT.java
@@ -20,14 +20,13 @@ import java.io.File;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 public class DefaultDevBundleIT extends AbstractPlatformTest {
 
-    @Test @Ignore("ignore while bundle is not correctly generated")
+    @Test
     public void test() throws Exception {
         File baseDir = new File(System.getProperty("user.dir", "."));
         File devBundle = new File(baseDir, "target/" + Constants.DEV_BUNDLE_LOCATION);
@@ -40,7 +39,7 @@ public class DefaultDevBundleIT extends AbstractPlatformTest {
         Assert.assertFalse("Error: folder '" + nodeModules.getPath() + "' shouldn't exist.", nodeModules.exists());
     }
 
-    @Test @Ignore("ignore while sw are not correctly generated")
+    @Test
     public void serviceWorkerIsIncludedAndServed() {
         getDriver().get(getRootURL() + "/sw.js");
         String pageSource = getDriver().getPageSource();


### PR DESCRIPTION
These tests were temporary disabled during the unification of hilla in platform, and needs to be re-enabled before beta1