### PR TITLE
fix: exclude Hilla from Vaadin Quarkus extension [skip ci]

### DIFF
--- a/vaadin-quarkus-extension/pom.xml
+++ b/vaadin-quarkus-extension/pom.xml
@@ -65,6 +65,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>hilla-dev</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Hilla dependency imports Spring that may not be wanted for a Quarkus based Vaadin application.
In addition, Hilla will currently not work on Quarkus because it uses Spring feature that are not supported by Quarkus extensions for Spring.