### PR TITLE
feat: Create vaadin-dev-flow and vaadin-dev-hilla

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
                 <module>vaadin-bom</module>
                 <module>vaadin-core-internal</module>
                 <module>vaadin-core</module>
+                <module>vaadin-dev-flow</module>
+                <module>vaadin-dev-hilla</module>
                 <module>vaadin-dev</module>
                 <module>vaadin-maven-plugin</module>
                 <module>vaadin-testbench</module>

--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -33,12 +33,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>hilla-dev</artifactId>
-            <version>${hilla.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spreadsheet-flow</artifactId>
             <version>${vaadin.spreadsheet.version}</version>
             <optional>true</optional>

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -45,6 +45,16 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-dev-flow</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-dev-hilla</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-dev</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -30,7 +30,7 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev-flow</artifactId>
+            <artifactId>vaadin-dev</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/vaadin-core/pom.xml
+++ b/vaadin-core/pom.xml
@@ -30,7 +30,7 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev</artifactId>
+            <artifactId>vaadin-dev-flow</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/vaadin-dev-flow/pom.xml
+++ b/vaadin-dev-flow/pom.xml
@@ -7,10 +7,10 @@
         <artifactId>vaadin-platform-parent</artifactId>
         <version>24.4-SNAPSHOT</version>
     </parent>
-    <artifactId>vaadin-dev</artifactId>
+    <artifactId>vaadin-dev-flow</artifactId>
     <packaging>jar</packaging>
-    <name>Vaadin Platform (vaadin-dev)</name>
-    <description>Vaadin Platform (vaadin-dev)</description>
+    <name>Vaadin Platform (vaadin-dev-flow)</name>
+    <description>Vaadin Platform (vaadin-dev-flow)</description>
     <url>https://vaadin.com</url>
 
     <distributionManagement>
@@ -33,17 +33,23 @@
     </dependencyManagement>
 
     <dependencies>
+
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev-flow</artifactId>
+            <artifactId>vaadin-dev-server</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev-hilla</artifactId>
+            <artifactId>vaadin-dev-bundle</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>copilot</artifactId>
+        </dependency>
+
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/vaadin-dev-hilla/pom.xml
+++ b/vaadin-dev-hilla/pom.xml
@@ -7,10 +7,10 @@
         <artifactId>vaadin-platform-parent</artifactId>
         <version>24.4-SNAPSHOT</version>
     </parent>
-    <artifactId>vaadin-dev</artifactId>
+    <artifactId>vaadin-dev-hilla</artifactId>
     <packaging>jar</packaging>
-    <name>Vaadin Platform (vaadin-dev)</name>
-    <description>Vaadin Platform (vaadin-dev)</description>
+    <name>Vaadin Platform (vaadin-dev-hilla)</name>
+    <description>Vaadin Platform (vaadin-dev-hilla)</description>
     <url>https://vaadin.com</url>
 
     <distributionManagement>
@@ -33,17 +33,23 @@
     </dependencyManagement>
 
     <dependencies>
+
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev-flow</artifactId>
+            <artifactId>vaadin-dev-server</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dev-hilla</artifactId>
+            <artifactId>hilla-dev</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>copilot</artifactId>
+        </dependency>
+
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/vaadin-dev/pom.xml
+++ b/vaadin-dev/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-hilla</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -57,6 +57,10 @@
             <groupId>com.vaadin</groupId>
             <artifactId>hilla</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-hilla</artifactId>
+        </dependency>
 
         <!-- Spring -->
         <dependency>


### PR DESCRIPTION
vaadin-dev no has vaadin-dev-flow and vaadin-dev-hilla.
vaadin-core depends on vaadin-dev-flow
to not get hilla if not wanted.

This will make vaadin and vaadin-core backwards
compatible with older version where hilla was not a dependency.

Implements part of #5230

Fixes #5260