### PR TITLE
chore: align hilla and flow versions with main 24.5-SNAPSHOT

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -122,7 +122,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "24.4.0.beta1"
+            "javaVersion": "24.5-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "15.0.1"
@@ -143,7 +143,7 @@
             "npmName": "@vaadin/grid"
         },
         "hilla": {
-            "javaVersion": "24.4.0.beta2"
+            "javaVersion": "24.5-SNAPSHOT"
         },
         "horizontal-layout": {
             "jsVersion": "24.4.0-beta2",


### PR DESCRIPTION
It will have a deployed version when we have the first alpha for 24.5
