### PR TITLE
chore: update appsec-kit-starter to 3.2.0.beta1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -376,7 +376,7 @@
     },
     "kits": {
         "appsec-kit-starter": {
-            "javaVersion": "3.1.0"
+            "javaVersion": "3.2.0.beta1"
         },
         "azure-kit": {
             "version": "1.0.0"


### PR DESCRIPTION
Platform SBOM switched from CycloneDX spec version 1.4 to 1.5 and this happened automatically (it probably uses the latest) while AppSec Kit 3.1 has version 1.4 managed by its POM. This might cause an exception when using kit with 24.4.

AppSec Kit 3.2 now uses the latest CycloneDX spec version 1.5.