### PR TITLE
chore: drop changeSince function [skip ci]

### DIFF
--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -135,12 +135,12 @@ function createReleaseNotes(versions, releaseNoteTemplate) {
     //const changed = getChangedSincePrevious(versions);
     //console.log(versions.platform);
     let releaseNoteData;
-    //if(!versions.platform.includes("SNAPSHOT")){
-    //    const componentNote = getComponentReleaseNote(versions.platform);
-    //    releaseNoteData = Object.assign(versions, { components: componentVersions }, { changesSincePrevious: changed }, { componentNote: componentNote });
-    //} else {
-    //    releaseNoteData = Object.assign(versions, { components: componentVersions }, { changesSincePrevious: changed });
-    //}
+    if(!versions.platform.includes("SNAPSHOT")){
+        const componentNote = getComponentReleaseNote(versions.platform);
+        releaseNoteData = Object.assign(versions, { components: componentVersions }, { componentNote: componentNote });
+    } else {
+        releaseNoteData = Object.assign(versions, { components: componentVersions });
+    }
 
     return render(releaseNoteTemplate, releaseNoteData);
 }


### PR DESCRIPTION
we dont generate that content with the releasenote template nowadays.
fix #6509 