### PR TITLE
chore: disable bomber temporarily [skip ci]

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -83,7 +83,7 @@ pre[b] {border: solid 1px darkgrey}
 </style>`;
 
 const cmd = {
-  useBomber: true, useOSV: true, useOWASP: true,
+  useBomber: false, useOSV: true, useOWASP: true,
   hasOssToken: !!(process.env.OSSINDEX_USER && process.env.OSSINDEX_TOKEN)
 };
 for (let i = 2, l = process.argv.length; i < l; i++) {

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -318,24 +318,26 @@ async function sumarizeDiffs(newSbomFile, oldSbomFile, currVersion, prevVersion)
 }
 
 function sumarizeOSV(f, summary) {
-  const res = JSON.parse(fs.readFileSync(f));
-  res.results && res.results.forEach(r => {
-    r.packages.forEach(p => {
-      p.vulnerabilities.forEach(v => {
-        v.affected.forEach(a => {
-          const pkg = a.package.purl + "@" + p.package.version;
-          summary[pkg] = summary[pkg] || {};
-          v.aliases && v.aliases.forEach(id => {
-            summary[pkg][id] = summary[pkg][id] || {};
-            summary[pkg][id].title = v.summary;
-            summary[pkg][id].details = v.details;
-            (summary[pkg][id].scanner = summary[pkg][id].scanner || []).push('osv-scan');
+  if (fs.readFileSync(f).length !== 0) {
+    const res = JSON.parse(fs.readFileSync(f));
+    res.results && res.results.forEach(r => {
+      r.packages.forEach(p => {
+        p.vulnerabilities.forEach(v => {
+          v.affected.forEach(a => {
+            const pkg = a.package.purl + "@" + p.package.version;
+            summary[pkg] = summary[pkg] || {};
+            v.aliases && v.aliases.forEach(id => {
+              summary[pkg][id] = summary[pkg][id] || {};
+              summary[pkg][id].title = v.summary;
+              summary[pkg][id].details = v.details;
+              (summary[pkg][id].scanner = summary[pkg][id].scanner || []).push('osv-scan');
+            });
           });
         });
       });
     });
-  });
-  return summary;
+    return summary;
+  }
 }
 
 function sumarizeBomber(f, summary) {


### PR DESCRIPTION
disable bomber temporarily, as there is a failure with error 
```
!! ERROR 1 !! running: bomber scan target/bom-vaadin.json --output json!!
■ json: cannot unmarshal number into Go struct field Severity.vulns.severity.type of type string
```

seems people are reporting this issue as in https://github.com/google/osv.dev/issues/2335