### PR TITLE
use docs link for prerelease version [skip ci]

### DIFF
--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -40,7 +40,7 @@ Vaadin {{platform}}
   - AppSec Kit ([{{kits.appsec-kit-starter.javaVersion}}](https://vaadin.com/docs/latest/tools/appsec))
   - Azure Kit ([{{kits.azure-kit.version}}](https://vaadin.com/docs/latest/tools/azure))
   - Collaboration Engine ([{{kits.vaadin-collaboration-engine.javaVersion}}](https://github.com/vaadin/collaboration-engine/releases/tag/{{kits.vaadin-collaboration-engine.javaVersion}}))
-  - Copilot ([{{kits.copilot.javaVersion}}](https://github.com/vaadin/copilot/releases/tag/{{kits.copilot.javaVersion}}))
+  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot))
   - Kubernetes Kit ([{{kits.kubernetes-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernetes-kit-starter.javaVersion}}))
   - Observability Kit ([{{kits.observability-kit-starter.javaVersion}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit-starter.javaVersion}}))
   - SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))


### PR DESCRIPTION
as we dont have release note for copilot prerelease version in the public repo 