### PR TITLE
fix: add popover package to React components exclusions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -452,6 +452,7 @@
                 "@vaadin/number-field",
                 "@vaadin/overlay",
                 "@vaadin/password-field",
+                "@vaadin/popover",
                 "@vaadin/progress-bar",
                 "@vaadin/radio-group",
                 "@vaadin/scroller",


### PR DESCRIPTION
## Description

I missed to include this change when adding Popover in #6637. This fixes wrong auto-import when using React.

## Type of change

- Bugfix