### PR TITLE
chore: prevent jandex artifacts to import transitive dependencies

### DIFF
--- a/vaadin-core-jandex/pom.xml
+++ b/vaadin-core-jandex/pom.xml
@@ -20,11 +20,22 @@
             <artifactId>vaadin-core</artifactId>
             <version>${project.version}</version>
             <exclusions>
+                <!--
+                    dev dependencies are usually excluded for production builds
+                    so they should not be indexed, to prevent classes to be found
+                    at build time but not at runtime.
+                -->
                 <exclusion>
                     <groupId>com.vaadin</groupId>
-                    <artifactId>hilla-dev</artifactId>
+                    <artifactId>vaadin-dev</artifactId>
+                </exclusion>
+                <!-- Potentially optional dependencies according to online documentation -->
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-react</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/vaadin-core-jandex/src/test/java/com/vaadin/jandex/JandexSmokeTest.java
+++ b/vaadin-core-jandex/src/test/java/com/vaadin/jandex/JandexSmokeTest.java
@@ -33,7 +33,29 @@ public class JandexSmokeTest {
             Assert.assertNotNull("Class from a component was not found",
                     classByName);
         }
+    }
 
+    @Test
+    public void generatedJandex_shouldNotContainsOptionalDependencies()
+            throws IOException {
+        try (InputStream jandexStream = JandexSmokeTest.class.getClassLoader()
+                .getResourceAsStream("META-INF/jandex.idx")) {
+            IndexReader reader = new IndexReader(jandexStream);
+            final Index index = reader.read();
+
+            ClassInfo classByName = index.getClassByName("com.vaadin.base.devserver.startup.DevModeStartupListener");
+            Assert.assertNull("Class from vaadin-dev-server was found",
+                    classByName);
+
+            classByName = index.getClassByName("com.vaadin.flow.component.react.ReactAdapterComponent");
+            Assert.assertNull("Class from flow-react was found",
+                    classByName);
+
+            classByName = index.getClassByName("com.vaadin.copilot.Copilot");
+            Assert.assertNull("Class from copilot was found",
+                    classByName);
+
+        }
     }
 
 }

--- a/vaadin-jandex/pom.xml
+++ b/vaadin-jandex/pom.xml
@@ -20,11 +20,22 @@
             <artifactId>vaadin</artifactId>
             <version>${project.version}</version>
             <exclusions>
+                <!--
+                    dev dependencies are usually excluded for production builds
+                    so they should not be indexed, to prevent classes to be found
+                    at build time but not at runtime.
+                -->
                 <exclusion>
                     <groupId>com.vaadin</groupId>
-                    <artifactId>hilla-dev</artifactId>
+                    <artifactId>vaadin-dev</artifactId>
+                </exclusion>
+                <!-- Potentially optional dependencies according to online documentation -->
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-react</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/vaadin-jandex/src/test/java/com/vaadin/jandex/JandexSmokeTest.java
+++ b/vaadin-jandex/src/test/java/com/vaadin/jandex/JandexSmokeTest.java
@@ -40,7 +40,30 @@ public class JandexSmokeTest {
                     classByName);
 
         }
-
     }
+
+    @Test
+    public void generatedJandex_shouldNotContainsOptionalDependencies()
+            throws IOException {
+        try (InputStream jandexStream = JandexSmokeTest.class.getClassLoader()
+                .getResourceAsStream("META-INF/jandex.idx")) {
+            IndexReader reader = new IndexReader(jandexStream);
+            final Index index = reader.read();
+
+            ClassInfo classByName = index.getClassByName("com.vaadin.base.devserver.startup.DevModeStartupListener");
+            Assert.assertNull("Class from vaadin-dev-server was found",
+                    classByName);
+
+            classByName = index.getClassByName("com.vaadin.flow.component.react.ReactAdapterComponent");
+            Assert.assertNull("Class from flow-react was found",
+                    classByName);
+
+            classByName = index.getClassByName("com.vaadin.copilot.Copilot");
+            Assert.assertNull("Class from copilot was found",
+                    classByName);
+
+        }
+    }
+
 
 }


### PR DESCRIPTION
This change makes jandex artifact dependencies provided scoped, to prevent to import transitive dependencies in the user project. It also excludes from the index potentially optional dependencies such as vaadin-dev-server (usually excluded from production builds) and flow-react (user can opt-out as documented online)

Part of vaadin/quarkus#158
