### PR TITLE
chore: Remove ui-tests dependency

### DIFF
--- a/scripts/generator/templates/template-release-notes-maintenance.md
+++ b/scripts/generator/templates/template-release-notes-maintenance.md
@@ -22,7 +22,7 @@ Vaadin {{platform}}
   - Azure Kit ([{{kits.azure-kit.version}}](https://vaadin.com/docs/latest/tools/azure))
   - Collaboration Engine ([{{kits.vaadin-collaboration-engine.javaVersion}}](https://github.com/vaadin/collaboration-engine/releases/tag/{{kits.vaadin-collaboration-engine.javaVersion}}))
   - Control Center ([Documentation](https://vaadin.com/docs/latest/control-center))
-  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot)) with UI-tests-Generator
+  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot))
   - Kubernetes Kit ([{{kits.kubernetes-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernetes-kit-starter.javaVersion}}))
   - Observability Kit ([{{kits.observability-kit-starter.javaVersion}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit-starter.javaVersion}}))
   - SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))

--- a/scripts/generator/templates/template-release-notes-prerelease.md
+++ b/scripts/generator/templates/template-release-notes-prerelease.md
@@ -42,7 +42,7 @@ Vaadin {{platform}}
   - Azure Kit ([{{kits.azure-kit.version}}](https://vaadin.com/docs/latest/tools/azure))
   - Collaboration Engine ([{{kits.vaadin-collaboration-engine.javaVersion}}](https://github.com/vaadin/collaboration-engine/releases/tag/{{kits.vaadin-collaboration-engine.javaVersion}}))
   - Control Center ([Documentation](https://vaadin.com/docs/latest/control-center))
-  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot)) with UI-tests-Generator
+  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot))
   - Kubernetes Kit ([{{kits.kubernetes-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernetes-kit-starter.javaVersion}}))
   - Observability Kit ([{{kits.observability-kit-starter.javaVersion}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit-starter.javaVersion}}))
   - SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))

--- a/scripts/generator/templates/template-release-notes.md
+++ b/scripts/generator/templates/template-release-notes.md
@@ -32,7 +32,7 @@ Vaadin {{platform}}
   - Azure Kit ([{{kits.azure-kit.version}}](https://vaadin.com/docs/latest/tools/azure))
   - Collaboration Engine ([{{kits.vaadin-collaboration-engine.javaVersion}}](https://github.com/vaadin/collaboration-engine/releases/tag/{{kits.vaadin-collaboration-engine.javaVersion}}))
   - Control Center ([Documentation](https://vaadin.com/docs/latest/control-center))
-  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot)) with UI-tests-Generator
+  - Copilot ([{{kits.copilot.javaVersion}}](https://vaadin.com/docs/latest/tools/copilot))
   - Kubernetes Kit ([{{kits.kubernetes-kit-starter.javaVersion}}](https://github.com/vaadin/kubernetes-kit/releases/tag/{{kits.kubernetes-kit-starter.javaVersion}}))
   - Observability Kit ([{{kits.observability-kit-starter.javaVersion}}](https://github.com/vaadin/observability-kit/releases/tag/{{kits.observability-kit-starter.javaVersion}}))
   - SSO Kit ([{{kits.sso-kit-starter.javaVersion}}](https://github.com/vaadin/sso-kit/releases/tag/{{kits.sso-kit-starter.javaVersion}}))

--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -204,13 +204,6 @@
                     <version>1.4.1</version>
                     <scope>provided</scope>
                 </dependency>
-                <!-- dependency used in ui-tests -->
-                <dependency>
-                    <groupId>com.microsoft.playwright</groupId>
-                    <artifactId>playwright</artifactId>
-                    <version>1.47.0</version>
-                    <scope>provided</scope>
-                </dependency>
             </dependencies>
             <build>
                 <plugins>

--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -168,17 +168,6 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>copilot</artifactId>
                 <version>${copilot.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>ui-tests</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>ui-tests</artifactId>
-                <version>${ui.tests.version}</version>
             </dependency>
             <!-- Free Components -->
             <dependency>

--- a/vaadin-dev/pom.xml
+++ b/vaadin-dev/pom.xml
@@ -53,10 +53,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>copilot</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>ui-tests</artifactId>
-        </dependency>
 
     </dependencies>
     <build>

--- a/versions.json
+++ b/versions.json
@@ -407,9 +407,6 @@
         "swing-kit": {
             "javaVersion": "2.2.3"
         },
-        "ui-tests": {
-            "javaVersion": "1.0.0"
-        },
         "vaadin-collaboration-engine": {
             "javaVersion": "6.3.0"
         }


### PR DESCRIPTION
The dependency is commercial so it cannot be a dependency of `vaadin-dev`. We cannot move it to be a dependency of `vaadin` either as it then will end up in the production artifacts.

Additionally it seems this is a dependency that should not be used in end user projects, at least not right now, so having it outside the platform is fine.

Fixes #6915