### PR TITLE
fix: dependency convergence error from copilot

### DIFF
--- a/vaadin-dev/pom.xml
+++ b/vaadin-dev/pom.xml
@@ -52,8 +52,75 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>copilot</artifactId>
+            <exclusions>
+                <!-- io.projectreactor.netty:reactor-netty:jar:1.1.24 brings vulnerable dependencies
+                and also failed the dependency convergence test, as netty-* has different versions   -->
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-unix-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
+            <version>4.1.115.Final</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/versions.json
+++ b/versions.json
@@ -391,7 +391,7 @@
             "javaVersion": "1.0.2"
         },
         "copilot": {
-            "javaVersion": "24.6.0.alpha4"
+            "javaVersion": "24.6-SNAPSHOT"
         },
         "kubernetes-kit-starter": {
             "javaVersion": "2.3.0"


### PR DESCRIPTION
- `dependency convergence` : there two different versions of io.netty:netty-* in this reactor-netty:1.2.0 , which are 4.1.114 and 4.1.113
- `vulnerable dependency` : the reactor-netty:1.2.0 uses io.netty:netty-common:4.1.114 which contains https://github.com/netty/netty/security/advisories/GHSA-xq3w-v528-46rv