### PR TITLE
chore: use node latest version [skip ci]

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -51,7 +51,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - uses: actions/setup-java@v4
         with:
           java-version: '17'

--- a/versions.json
+++ b/versions.json
@@ -388,7 +388,7 @@
             "version": "1.0.0"
         },
         "control-center": {
-            "javaVersion": "1.1.0.beta1"
+            "javaVersion": "1.1.0.beta2"
         },
         "copilot": {
             "javaVersion": "24.6.0.beta1"


### PR DESCRIPTION
```
TypeError: licenseWhiteList.toSpliced is not a function
```

Array.prototype.toSpliced() is relatively new feature of node.js, not part of the ECMAScript standard. Even Chrome has these methods available only since version 110 and node only since version 20.0.0 