### PR TITLE
revert the Pit JDK change [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -119,7 +119,7 @@ jobs:
           node-version: '18'
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
       - uses: stCarolas/setup-maven@v5
         with:


### PR DESCRIPTION
JDK 21 need jackson 2.18 to work.. and in Vaadin 24.5, we are still using jackson 2.17..
