### PR TITLE
chore: add a workaround to resolve the no version in the range [skip ci]

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -76,6 +76,10 @@ const cveWhiteList = {
   'pkg:npm/micromatch@4.0.7' : {
       cves: ['CVE-2024-4067'],
       description: 'Based on the assumption that the code is only run as part of a build, we take this as a false positive. Also we are tracking the development process to upgrade the vulnerable dependencies.'
+  },
+  'pkg:maven/io.netty/netty-common@4.1.118.Final' : {
+    cves: ['CVE-2025-25193'],
+    description: 'the cve has wrong version range, the related commit has been merged and released with 118.Final. referred in netty/issues/14795'
   }
 
 }

--- a/vaadin-platform-sbom/pom.xml
+++ b/vaadin-platform-sbom/pom.xml
@@ -24,6 +24,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>2.4.10</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
issue https://github.com/netplex/json-smart-v2/issues/240
```
No versions available for net.minidev:json-smart:jar:[1.3.3,2.4.10] within specified range 
```