### PR TITLE
chore: disable feature flags in default bundles

### DIFF
--- a/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeFeatureFlagsReset.java
+++ b/vaadin-dev-bundle/src/main/java/com/vaadin/devbundle/FakeFeatureFlagsReset.java
@@ -1,0 +1,45 @@
+package com.vaadin.devbundle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
+
+/**
+ * Disables all feature flags in the bundle before running Vite build.
+ */
+public class FakeFeatureFlagsReset implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options, FrontendDependenciesScanner frontendDependenciesScanner) {
+        File frontendGeneratedDirectory = new File(
+                options.getFrontendDirectory(), GENERATED);
+        Path featureFlagsJS = new File(frontendGeneratedDirectory, FEATURE_FLAGS_FILE_NAME).toPath();
+        if (Files.exists(featureFlagsJS)) {
+            try {
+                Files.write(featureFlagsJS,
+                        Files.readAllLines(featureFlagsJS)
+                                .stream().map(line -> {
+                                    if (line.startsWith("window.Vaadin.featureFlags.") && line.endsWith("= true;")) {
+                                        return line.replace("= true;", "= false;");
+                                    }
+                                    return line;
+                                }).toList(), StandardOpenOption.TRUNCATE_EXISTING);
+
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+}

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -112,7 +112,7 @@ public class ComponentsIT extends AbstractPlatformTest {
         assertTrue($.exists());
         String tagName = $.first().getTagName().toLowerCase();
         if (tagName.contains("-")) {
-            assertTrue((Boolean) executeScript("return !!window.customElements.get(arguments[0])", tagName));
+            assertTrue("Check failed for component " + tagName, (Boolean) executeScript("return !!window.customElements.get(arguments[0])", tagName));
         }
     }
 }

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeFeatureFlagsReset.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeFeatureFlagsReset.java
@@ -1,0 +1,44 @@
+package com.vaadin.prodbundle;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TypeScriptBootstrapModifier;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
+
+/**
+ * Disables all feature flags in the bundle before running Vite build.
+ */
+public class FakeFeatureFlagsReset implements TypeScriptBootstrapModifier {
+
+    @Override
+    public void modify(List<String> bootstrapTypeScript, Options options, FrontendDependenciesScanner frontendDependenciesScanner) {
+        File frontendGeneratedDirectory = new File(
+                options.getFrontendDirectory(), GENERATED);
+        Path featureFlagsJS = new File(frontendGeneratedDirectory, FEATURE_FLAGS_FILE_NAME).toPath();
+        if (Files.exists(featureFlagsJS)) {
+            try {
+                Files.write(featureFlagsJS,
+                        Files.readAllLines(featureFlagsJS)
+                                .stream().map(line -> {
+                                    if (line.startsWith("window.Vaadin.featureFlags.") && line.endsWith("= true;")) {
+                                        return line.replace("= true;", "= false;");
+                                    }
+                                    return line;
+                                }).toList(), StandardOpenOption.TRUNCATE_EXISTING);
+
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/FeatureFlagsResetTest.java
+++ b/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/FeatureFlagsResetTest.java
@@ -1,0 +1,63 @@
+package com.vaadin.prodbundle;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FeatureFlagsResetTest {
+
+    @Test
+    public void featureFlagsReset() throws IOException {
+        Predicate<String> enabledFeatureFlag = Pattern.compile("window\\.Vaadin\\.featureFlags\\..*=!0;").asPredicate();
+        int foundInFiles = findInBundleBuildFolder(enabledFeatureFlag);
+        Assertions.assertEquals(0, foundInFiles,
+                "Expecting all feature flags should be disabled in the dev-bundle");
+    }
+
+    private int findInBundleBuildFolder(Predicate<String> matcher)
+            throws IOException {
+        Path bundlerBuildFolder = Paths.get("target", "classes", "META-INF", "VAADIN", "webapp",
+                "VAADIN", "build");
+        return findInFiles(bundlerBuildFolder, matcher);
+    }
+
+    private int findInFiles(Path path, Predicate<String> matcher)
+            throws IOException {
+        AtomicInteger foundInFiles = new AtomicInteger();
+        Files.walkFileTree(path, new SimpleFileVisitor<>() {
+
+            @Override
+            public FileVisitResult visitFile(Path file,
+                                             BasicFileAttributes attrs) throws IOException {
+                if (file.getFileName().toString().endsWith(".js")) {
+                    List<String> lines = FileUtils.readLines(file.toFile(),
+                            StandardCharsets.UTF_8);
+                    for (String line : lines) {
+                        if (matcher.test(line)) {
+                            foundInFiles.incrementAndGet();
+                            break;
+                        }
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return foundInFiles.get();
+
+    }
+
+
+}


### PR DESCRIPTION
Updates vaadin-featureflags.js before running Vite to disable all feature flags in the bundle.

Releated to vaadin/flow#20991
