### PR TITLE
feat: add Card Flow API preview to 24.7

### DIFF
--- a/scripts/generator/templates/template-vaadin-spring-bom.xml
+++ b/scripts/generator/templates/template-vaadin-spring-bom.xml
@@ -198,6 +198,11 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-card-flow</artifactId>
+                <version>${card.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-checkbox-flow</artifactId>
                 <version>${checkbox.version}</version>
             </dependency>
@@ -382,6 +387,11 @@
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-button-testbench</artifactId>
                 <version>${button.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-card-testbench</artifactId>
+                <version>${card.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>

--- a/vaadin-core-components/pom.xml
+++ b/vaadin-core-components/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-card-flow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-checkbox-flow</artifactId>
         </dependency>
         <dependency>

--- a/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,4 @@
 # Dashboard Component (Experimental)
 com.vaadin.experimental.dashboardComponent=true
+# Card Component (Experimental)
+com.vaadin.experimental.cardComponent=true

--- a/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
+++ b/vaadin-platform-hybrid-test/frontend/views/components/components-view.ts
@@ -6,6 +6,7 @@ import '@vaadin/avatar';
 import '@vaadin/avatar-group';
 import '@vaadin/board';
 import '@vaadin/board/src/vaadin-board-row';
+import '@vaadin/card';
 import '@vaadin/icon';
 import '@vaadin/scroller';
 import '@vaadin/virtual-list';
@@ -155,6 +156,12 @@ export class ComponentsView extends View {
         <vaadin-tooltip text="Click to save changes" for="confirm"></vaadin-tooltip>
         <vaadin-button theme="secondary">Secondary</vaadin-button>
         <vaadin-button theme="tertiary">Tertiary</vaadin-button>
+
+        <vaadin-card>
+          <div slot="title">Lapland</div>
+          <div slot="subtitle">The Exotic North</div>
+          <div>Lapland is the northern-most region of Finland and an active outdoor destination.</div>
+        </vaadin-card>
 
         <vaadin-icon name="vaadin:user"></vaadin-icon>
         <vaadin-iconset name="foo" size="16">

--- a/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
+++ b/vaadin-platform-test/src/main/java/com/vaadin/platform/test/ComponentsView.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.component.avatar.AvatarGroup.AvatarGroupItem;
 import com.vaadin.flow.component.board.Board;
 import com.vaadin.flow.component.board.Row;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.charts.Chart;
 import com.vaadin.flow.component.charts.model.ChartType;
 import com.vaadin.flow.component.charts.model.ListSeries;
@@ -281,6 +282,10 @@ public class ComponentsView extends AppLayout {
             log.log("Clicked button");
         });
         button.setIcon(icon);
+
+        Card card = new Card();
+        card.setTitle(new Div("Lapland"));
+        card.add(new Div("Lapland is the northern-most region of Finland and an active outdoor destination."));
 
         Checkbox checkbox = new Checkbox("Checkbox label");
         log.log("Checkbox default is " + checkbox.getValue());
@@ -667,6 +672,7 @@ public class ComponentsView extends AppLayout {
         WebComponentWrapper webComponentWrapper;
 
         components.add(button);
+        components.add(card);
         components.add(checkbox);
         components.add(checkboxGroup);
         components.add(comboBox);

--- a/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,4 @@
 # Dashboard Component (Experimental)
 com.vaadin.experimental.dashboardComponent=true
+# Card Component (Experimental)
+com.vaadin.experimental.cardComponent=true

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.avatar.AvatarGroup;
 import com.vaadin.flow.component.board.Board;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.card.Card;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -76,6 +77,7 @@ public class EagerView extends Div {
     public Board board;
     public BigDecimalField bigDecimalField;
     public Button button;
+    public Card card;
     public Checkbox checkbox;
     public CheckboxGroup<String> checkboxGroup;
     public ComboBox<String> comboBox;

--- a/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,4 @@
 # Dashboard Component (Experimental)
 com.vaadin.experimental.dashboardComponent=true
+# Card Component (Experimental)
+com.vaadin.experimental.cardComponent=true

--- a/vaadin-testbench-junit5/pom.xml
+++ b/vaadin-testbench-junit5/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-card-testbench</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-charts-testbench</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-card-testbench</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-charts-testbench</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/versions.json
+++ b/versions.json
@@ -41,6 +41,12 @@
             "mode": "lit",
             "npmName": "@vaadin/button"
         },
+        "card": {
+            "javaVersion": "{{version}}",
+            "jsVersion": "24.7.1",
+            "mode": "lit",
+            "npmName": "@vaadin/card"
+        },
         "checkbox": {
             "javaVersion": "{{version}}",
             "jsVersion": "24.7.2",
@@ -420,6 +426,7 @@
                 "@vaadin/avatar",
                 "@vaadin/avatar-group",
                 "@vaadin/button",
+                "@vaadin/card",
                 "@vaadin/checkbox",
                 "@vaadin/checkbox-group",
                 "@vaadin/combo-box",

--- a/versions.json
+++ b/versions.json
@@ -43,7 +43,7 @@
         },
         "card": {
             "javaVersion": "{{version}}",
-            "jsVersion": "24.7.1",
+            "jsVersion": "24.7.2",
             "mode": "lit",
             "npmName": "@vaadin/card"
         },


### PR DESCRIPTION
## Description

Adds the Card Flow component as preview feature to 24.7.

Depends on https://github.com/vaadin/flow-components/pull/7275 to be released first, as compilation for `card.setTitle` will fail otherwise.

## Type of change

- Feature
