### PR TITLE
chore: downgrade helm version to avoid regression introduced in 3.18.0 [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -139,6 +139,8 @@ jobs:
       - name: Set up Helm
         if: ${{ matrix.app == 'control-center' }}
         uses: azure/setup-helm@v3.5
+        with:
+          version: 3.17.3
       - name: Create k8s Kind Cluster
         if: ${{ matrix.app == 'control-center' }}
         uses: helm/kind-action@v1


### PR DESCRIPTION
related to: https://github.com/helm/helm/issues/30878
workaround for: https://github.com/vaadin/control-center/issues/929

