### PR TITLE
Revert "chore: downgrade helm version to avoid regression introduced in 3.18.0 (#7651)" [skip ci]

### DIFF
--- a/.github/workflows/pit.yml
+++ b/.github/workflows/pit.yml
@@ -139,8 +139,6 @@ jobs:
       - name: Set up Helm
         if: ${{ matrix.app == 'control-center' }}
         uses: azure/setup-helm@v3.5
-        with:
-          version: 3.17.3
       - name: Create k8s Kind Cluster
         if: ${{ matrix.app == 'control-center' }}
         uses: helm/kind-action@v1


### PR DESCRIPTION


This reverts commit 63ec5aedb524566207e7b8098a947d774b3f7fad.
