### PR TITLE
Chore: Update Collaboration Kit to 6.5.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -426,7 +426,7 @@
             "javaVersion": "2.4.0"
         },
         "vaadin-collaboration-engine": {
-            "javaVersion": "6.4.0"
+            "javaVersion": "6.5.0"
         }
     },
     "platform": "{{version}}",


### PR DESCRIPTION
Updates Collaboration Kit (`vaadin-collaboration-engine`) to version 6.5.0