### PR TITLE
chore: provide spring-boot-webmvc dependency for javadoc generation [skip ci]

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -192,6 +192,11 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-webmvc</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
                     <groupId>org.junit.jupiter</groupId>
                     <artifactId>junit-jupiter-api</artifactId>
                     <version>${junit.jupiter.version}</version>


### PR DESCRIPTION
this dependency has been imported with springboot 4.0