### PR TITLE
chore: fix prod bundle test after the recent theme changes

### DIFF
--- a/vaadin-prod-bundle/frontend/themes/vaadin-prod-bundle/theme.json
+++ b/vaadin-prod-bundle/frontend/themes/vaadin-prod-bundle/theme.json
@@ -1,3 +1,0 @@
-{
-  "lumoImports": ["typography", "color", "spacing", "badge", "utility"]
-}

--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/FakeAppConf.java
@@ -5,9 +5,7 @@ import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.LoadDependenciesOnStartup;
 import com.vaadin.flow.server.PWA;
-import com.vaadin.flow.theme.Theme;
 
-@Theme("vaadin-prod-bundle")
 @PWA(name = "vaadin-prod-bundle", shortName = "vaadin-prod-bundle")
 @LoadDependenciesOnStartup(EagerView.class)
 @JsModule(DndUtil.DND_CONNECTOR)  

--- a/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/AllComponentsIncludedTest.java
+++ b/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/AllComponentsIncludedTest.java
@@ -92,8 +92,8 @@ public class AllComponentsIncludedTest {
                 .stream(optimizedStats.getArray("bundleImports"))
                 .map(v -> v.asString()).toList();
 
-        File generatedImports = Path.of("frontend", "generated", "flow",
-                "generated-flow-imports.js").toFile();
+        File generatedImports = Path.of("src", "main", "frontend", "generated",
+                "flow", "generated-flow-imports.js").toFile();
         Assertions.assertTrue(generatedImports.exists(),
                 "Generated imports file " + generatedImports.getAbsolutePath()
                         + " is missing");

--- a/versions.json
+++ b/versions.json
@@ -112,7 +112,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "25.0.0-alpha12"
+            "javaVersion": "25.0-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "16.0.0-alpha1"


### PR DESCRIPTION
```
this theme in vaadin-prod-bundle was added to include Lumo into the default prod bundle. I agree we now can remove the @Theme(“vaadin-prod-bundle”) and corresponding theme folder.
```