### PR TITLE
chore: mark jars as development-tool

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -129,6 +129,12 @@
                         <exclude>**/*Fake*</exclude>
                         <exclude>vaadin-featureflags.properties</exclude>
                     </excludes>
+                    <archive>
+                        <manifestEntries>
+                            <Spring-Boot-Jar-Type>development-tool
+                            </Spring-Boot-Jar-Type>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/vaadin-dev/pom.xml
+++ b/vaadin-dev/pom.xml
@@ -101,6 +101,17 @@
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Spring-Boot-Jar-Type>development-tool</Spring-Boot-Jar-Type>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Add Spring-Boot-Jar-Type: development-tool to vaadin-dev and vaadin-dev-bundle manifest to exclude it from Spring Boot uber-jar package automatically.

RelatesTo: vaadin/flow#17737

WIP: `development-tool` type is new feature available in Spring Boot 4 RC. In current state Spring boot removes dependency always in runtime. Need to have it to be excluded only from the uber-jar package build for production, before this can be merged.