### PR TITLE
feat: add extensions support to vaadin-maven-plugin

### DIFF
--- a/vaadin-platform-test/pom-dev.xml
+++ b/vaadin-platform-test/pom-dev.xml
@@ -106,11 +106,6 @@
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-maven-plugin</artifactId>
-                <extensions>true</extensions>
-            </plugin>
         </plugins>
     </build>
 
@@ -198,6 +193,17 @@
                               </target>
                             </configuration>
                           </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-frontend</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -164,7 +164,13 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-maven-plugin</artifactId>
-                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -248,6 +254,17 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-frontend</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>3.0.0</version>
                         <executions>
@@ -266,5 +283,29 @@
             </build>
         </profile>
 
+        <profile>
+            <!-- Production mode is activated using -Pproduction -->
+            <id>production</id>
+            <activation>
+                <property>
+                    <name>vaadin.productionMode</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>build-frontend</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Summary

Add extensions support to vaadin-maven-plugin so users can simplify their pom.xml configuration.

With `<extensions>true</extensions>`, prepare-frontend and build-frontend goals run automatically in their default phases without needing explicit `<executions>` blocks.

**Before:**
```xml
<plugin>
    <groupId>com.vaadin</groupId>
    <artifactId>vaadin-maven-plugin</artifactId>
    <executions>
        <execution>
            <goals>
                <goal>prepare-frontend</goal>
                <goal>build-frontend</goal>
            </goals>
        </execution>
    </executions>
</plugin>
```

**After:**

```xml
<plugin>
    <groupId>com.vaadin</groupId>
    <artifactId>vaadin-maven-plugin</artifactId>
    <extensions>true</extensions>
</plugin>
```
This is fully opt-in - users can still use the traditional syntax with explicit executions if they prefer.

Using extensions also makes it easier for us to change goals or phases in future versions without requiring users to update their pom.xml files.