### PR TITLE
fix: Set required Java and Maven versions in vaadin-maven-plugin (24.10)

### DIFF
--- a/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
+++ b/scripts/generator/templates/template-vaadin-maven-plugin-pom.xml
@@ -73,9 +73,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.15.0</version>
+                    <version>3.15.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                        <requiredJavaVersion>17</requiredJavaVersion>
+                        <requiredMavenVersion>3.5</requiredMavenVersion>
                     </configuration>
                     <executions>
                         <execution>
@@ -189,7 +191,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.15.2</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
