### PR TITLE
fix: Set required Java and Maven versions in vaadin-maven-plugin (14.10)

### DIFF
--- a/vaadin-maven-plugin/pom.xml
+++ b/vaadin-maven-plugin/pom.xml
@@ -65,9 +65,11 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.5</version>
+                    <version>3.15.2</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                        <requiredJavaVersion>1.8</requiredJavaVersion>
+                        <requiredMavenVersion>3.5</requiredMavenVersion>
                     </configuration>
                     <executions>
                         <execution>
@@ -143,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.15.2</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Prevents potential issues with Maven versions >= 3.9.12 if a Java version newer than the supported one is used to package the Maven plugin.
