### PR TITLE
chore: add slider to react-components exclusions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -434,6 +434,7 @@
                 "@vaadin/scroller",
                 "@vaadin/select",
                 "@vaadin/side-nav",
+                "@vaadin/slider",
                 "@vaadin/split-layout",
                 "@vaadin/tabs",
                 "@vaadin/tabsheet",


### PR DESCRIPTION
## Description

I missed to add `@vaadin/slider` to the list of exclusions for `@vaadin/react-components`. This PR fixes that.

## Type of change

- Internal change