### PR TITLE
Added suggestion of code examples to Solution section

### DIFF
--- a/.github/ISSUE_TEMPLATE/prd.yml
+++ b/.github/ISSUE_TEMPLATE/prd.yml
@@ -48,7 +48,7 @@ body:
         <the user problem this feature will solve>
          
         #### Solution
-        <a detailed description of the soltion; images welcome>
+        <a detailed description of the soltion; images and code examples welcome>
          
         #### Notes
         <optional; e.g. an explanation of why this particular solution was chosen instead of some other options, or links to existing related github issues.>


### PR DESCRIPTION
Although PRDs don't need to (and probably shouldn't) specify the API design, it's useful to provide some code examples of how the feature would be used in code (if it's a feature with an API), so I added _"and code examples"_ to the placeholder for the _Solution_ section.