### PR TITLE
chore: add the ui-unit-test module to testbench artifacts

### DIFF
--- a/vaadin-testbench-junit5/pom.xml
+++ b/vaadin-testbench-junit5/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>vaadin-testbench-core-junit5</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-unit-junit5</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Flow HTML components -->
         <dependency>

--- a/vaadin-testbench-junit6/pom.xml
+++ b/vaadin-testbench-junit6/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>vaadin-testbench-core-junit6</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-unit-junit6</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Flow HTML components -->
         <dependency>

--- a/vaadin-testbench/pom.xml
+++ b/vaadin-testbench/pom.xml
@@ -38,6 +38,11 @@
             <artifactId>vaadin-testbench-core</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-unit</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Flow HTML components -->
         <dependency>


### PR DESCRIPTION
It seems these modules have been missing since the begining. 
it should be shipped with vaadin-testbench(-junitX) modules 
based on the origin ticket https://github.com/vaadin/platform/issues/3422