### PR TITLE
chore: update jsVersion for badge to 25.1.0-alpha9

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -31,7 +31,7 @@
             "npmName": "@vaadin/avatar-group"
         },
         "badge": {
-            "jsVersion": "25.1.0-alpha8",
+            "jsVersion": "25.1.0-alpha9",
             "mode": "lit",
             "npmName": "@vaadin/badge"
         },


### PR DESCRIPTION
## Description

The badge version wasn't correctly updated. This PR fixes it.

## Type of change

- Internal change