### PR TITLE
chore: optimize the sbom scanning script [skip ci]

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -32,6 +32,11 @@ on:
             required: false
             type: boolean
             default: false
+          updateNVD:
+            description: 'Force NVD database update (ignore cache)'
+            required: false
+            type: boolean
+            default: false
           version:
             description: 'Use set Platform Version to:'
             required: false
@@ -79,6 +84,13 @@ jobs:
           mkdir -p ~/.vaadin/
           echo '{"username":"'`echo ${{secrets.TB_LICENSE}} | cut -d / -f1`'","proKey":"'`echo ${{secrets.TB_LICENSE}} | cut -d / -f2`'"}' > ~/.vaadin/proKey
         name: Install proKey
+      - name: Restore NVD database cache
+        id: nvd-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/nvd-cache
+          key: nvd-db-will-not-match
+          restore-keys: nvd-db-
       - run: |
           [ false = "${{github.event.inputs.useBomber}}" ] && A="$A --disable-bomber"
           [ false = "${{github.event.inputs.useOSV}}" ] && A="$A --disable-osv-scan"
@@ -87,6 +99,9 @@ jobs:
           [ true = "${{github.event.inputs.useSnapshots}}" ] && A="$A --useSnapshots"
           V="${{ github.event.inputs.version || github.event.release.tag_name }}"
           [ -n "$V" ] && A="$A --version $V"
+          if [ "${{ steps.nvd-cache.outputs.cache-matched-key }}" != "" ] && [ true != "${{ github.event.inputs.updateNVD }}" ]; then
+            A="$A --nvd-cache-dir /tmp/nvd-cache --skip-nvd-update"
+          fi
           cmd="scripts/generateAndCheckSBOM.js $A"
           echo "Running: $cmd"
           $cmd

--- a/.github/workflows/update-nvd-db.yml
+++ b/.github/workflows/update-nvd-db.yml
@@ -1,0 +1,38 @@
+name: Update NVD Database Cache
+on:
+  schedule:
+    - cron: '0 2 * * *' # Daily at 2am UTC
+  workflow_dispatch:
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secrets
+        run: |
+          [ -z "${{secrets.NVD_API_KEY}}" ] \
+            && echo "🚫 **NVD_API_KEY** is not defined" \
+            | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
+      - name: Install dependency-check
+        run: |
+          cd /tmp
+          wget -q https://github.com/dependency-check/DependencyCheck/releases/download/v12.1.9/dependency-check-12.1.9-release.zip
+          unzip dependency-check-12.1.9-release.zip
+          sudo ln -s /tmp/dependency-check/bin/dependency-check.sh /usr/bin/dependency-check
+      - name: Restore previous NVD cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/nvd-cache
+          key: nvd-db-will-not-match
+          restore-keys: nvd-db-
+      - name: Update NVD database
+        run: |
+          mkdir -p /tmp/nvd-cache
+          dependency-check --updateonly \
+            --data /tmp/nvd-cache \
+            --nvdApiKey ${{ secrets.NVD_API_KEY }} \
+            --nvdApiDelay 6000
+      - name: Save NVD cache
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/nvd-cache
+          key: nvd-db-${{ github.run_id }}

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -125,9 +125,11 @@ for (let i = 2, l = process.argv.length; i < l; i++) {
     case '--compare': cmd.org = process.argv[++i]; break;
     case '--quick': cmd.quick = true; break;
     case '--skip-check-core-licenses' : cmd.checkCoreLicenses = false; break;
+    case '--nvd-cache-dir': cmd.nvdCacheDir = process.argv[++i]; break;
+    case '--skip-nvd-update': cmd.skipNvdUpdate = true; break;
     default:
       console.log(`Usage: ${path.relative('.', process.argv[1])}
-       [--useSnapshots] [--disable-bomber] [--disable-osv-scan] [--disable-owasp] [--enable-full-owasp] [--version x.x.x] [--quick] [--skip-check-core-licenses]`);
+       [--useSnapshots] [--disable-bomber] [--disable-osv-scan] [--disable-owasp] [--enable-full-owasp] [--version x.x.x] [--quick] [--skip-check-core-licenses] [--nvd-cache-dir <path>] [--skip-nvd-update]`);
       process.exit(1);
   }
 }
@@ -615,12 +617,20 @@ async function main() {
     // https://github.com/jeremylong/DependencyCheck/issues/4293
     // https://github.com/jeremylong/DependencyCheck/issues/1947
     fs.existsSync('package-lock.json') && fs.unlinkSync('package-lock.json')
-    !cmd.quick && await run(`mvn org.owasp:dependency-check-maven:check -DnvdApiKey=${process.env.NVD_API_KEY} -DnvdApiDelay=6000 -Dformat=JSON -q`, { throw: false });
+    let owaspArgs = `-DnvdApiKey=${process.env.NVD_API_KEY} -DnvdApiDelay=6000 -Dformat=JSON -q`;
+    if (cmd.nvdCacheDir) owaspArgs += ` -DdataDirectory=${cmd.nvdCacheDir}`;
+    if (cmd.skipNvdUpdate) owaspArgs += ` -DautoUpdate=false`;
+    log(cmd.skipNvdUpdate ? `OWASP: using cached NVD database from ${cmd.nvdCacheDir}` : 'OWASP: downloading NVD database (no cache or update forced)');
+    !cmd.quick && await run(`mvn org.owasp:dependency-check-maven:check ${owaspArgs}`, { throw: false });
     sumarizeOWASP('target/dependency-check-report.json', vulnerabilities);
   }
 
   if (cmd.useFullOWASP) {
-    !cmd.quick && await run('dependency-check -f JSON -f HTML --prettyPrint --out target --scan .');
+    let fullOwaspArgs = '-f JSON -f HTML --prettyPrint --out target --scan .';
+    if (cmd.nvdCacheDir) fullOwaspArgs += ` --data ${cmd.nvdCacheDir}`;
+    if (cmd.skipNvdUpdate) fullOwaspArgs += ` --noupdate`;
+    log(cmd.skipNvdUpdate ? `Full OWASP: using cached NVD database from ${cmd.nvdCacheDir}` : 'Full OWASP: downloading NVD database (no cache or update forced)');
+    !cmd.quick && await run(`dependency-check ${fullOwaspArgs}`);
     sumarizeOWASP('target/dependency-check-report.json', vulnerabilities);
   }
 


### PR DESCRIPTION
original issue:   
---
 The key bottleneck is on line 618 where dependency-check-maven:check downloads the NVD database every run, and line 623 for the full OWASP check.
 
 the solution is: 
---                                                                                                                                                                                                                            
  Changes made                                                                                                                                                                                                                     
                                                                                                                                                                                                                                   
  New file: .github/workflows/update-nvd-db.yml                                                                                                                                                                                    
  - Runs daily at 2am UTC via cron schedule                                                                                                                                                                                        
  - Can also be triggered manually (workflow_dispatch)                                                                                                                                                                           
  - Restores the previous NVD cache (if any), then runs dependency-check --updateonly to fetch the latest CVE data into /tmp/nvd-cache
  - Saves the updated database to GitHub Actions cache with key nvd-db-<run_id>

  Modified: .github/workflows/sbom.yml
  - Added updateNVD input (default: false) to force a fresh NVD download when running manually
  - Added a cache restore step (actions/cache/restore@v4) before the SBOM script
  - When the cache is restored and updateNVD is not set, passes --nvd-cache-dir /tmp/nvd-cache --skip-nvd-update to the script
  - If there's no cache hit or updateNVD=true, the script downloads the DB as before

  Modified: scripts/generateAndCheckSBOM.js
  - Added --nvd-cache-dir <path> flag — sets -DdataDirectory for Maven plugin and --data for standalone CLI
  - Added --skip-nvd-update flag — sets -DautoUpdate=false for Maven plugin and --noupdate for standalone CLI

  How it works

  1. The update-nvd-db.yml workflow runs daily and populates the cache with a fresh NVD database
  2. When sbom.yml runs, it restores the cached DB and tells dependency-check to use it without re-downloading
  3. If the cache is missing (first run, or cache expired after 7 days of inactivity), the SBOM workflow falls back to downloading the DB as it does today
  4. You can force a fresh download by setting updateNVD=true on manual runs, or by manually triggering the Update NVD Database Cache workflow
