### PR TITLE
chore: improve the sbom checking script

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -51,17 +51,17 @@ jobs:
             && echo "🚫 **TB_LICENSE** is not defined, check that **${{github.repository}}** repo has a valid secret" \
             | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
         name: Check secrets
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: stCarolas/setup-maven@v5
+      - uses: stCarolas/setup-maven@v5.1
         with:
           maven-version: '3.8.2'
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 'stable'
       - run: go install github.com/google/osv-scanner/cmd/osv-scanner@v1
@@ -70,13 +70,13 @@ jobs:
           sudo dpkg -i bomber_0.5.1_linux_amd64.deb
         name: Install bomber-0.5.1
       - run: |
-          # Install dependency-check-12.1.9
+          # Keep version in sync with scripts/generateAndCheckSBOM.js and .github/workflows/update-nvd-db.yml — NVD cache schema must match.
           cd /tmp
-          wget -q https://github.com/dependency-check/DependencyCheck/releases/download/v12.1.9/dependency-check-12.1.9-release.zip
-          unzip dependency-check-12.1.9-release.zip
+          wget -q https://github.com/dependency-check/DependencyCheck/releases/download/v12.2.2/dependency-check-12.2.2-release.zip
+          unzip dependency-check-12.2.2-release.zip
           sudo ln -s /tmp/dependency-check/bin/dependency-check.sh /usr/bin/dependency-check
-        name: Install dependency-check-12.1.9
-      - uses: actions/setup-node@v4
+        name: Install dependency-check-12.2.2
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
       - run: npm install --ignore-scripts -g npm@11.6.4
@@ -86,7 +86,7 @@ jobs:
         name: Install proKey
       - name: Restore NVD database cache
         id: nvd-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/nvd-cache
           key: nvd-db-will-not-match
@@ -111,12 +111,25 @@ jobs:
          OSSINDEX_TOKEN: ${{secrets.OSSINDEX_TOKEN}}
          NVD_API_KEY: ${{secrets.NVD_API_KEY}}
       - if: ${{always() && env.DEPENDENCIES_REPORT && github.event.pull_request}}
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          message: "${{env.DEPENDENCIES_REPORT}}\n[[Click for more Details](${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}})]"
-          comment_tag: dependencies_report
+        name: Upsert dependencies report PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REPORT: ${{ env.DEPENDENCIES_REPORT }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          MARKER='<!-- dependencies_report -->'
+          BODY=$(printf '%s\n%s\n[[Click for more Details](%s)]' "$MARKER" "$REPORT" "$RUN_URL")
+          id=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty")
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$id" -f body="$BODY"
+          else
+            gh api "repos/$REPO/issues/$PR/comments" -f body="$BODY"
+          fi
       - if: ${{always()}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: files
           path: |

--- a/.github/workflows/update-nvd-db.yml
+++ b/.github/workflows/update-nvd-db.yml
@@ -13,6 +13,7 @@ jobs:
             && echo "🚫 **NVD_API_KEY** is not defined" \
             | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
       - name: Install dependency-check
+        # Keep version in sync with scripts/generateAndCheckSBOM.js and .github/workflows/sbom.yml — NVD cache schema must match.
         run: |
           cd /tmp
           wget -q https://github.com/dependency-check/DependencyCheck/releases/download/v12.2.2/dependency-check-12.2.2-release.zip

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -625,7 +625,8 @@ async function main() {
     if (cmd.nvdCacheDir) owaspArgs += ` -DdataDirectory=${cmd.nvdCacheDir}`;
     if (cmd.skipNvdUpdate) owaspArgs += ` -DautoUpdate=false`;
     log(cmd.skipNvdUpdate ? `OWASP: using cached NVD database from ${cmd.nvdCacheDir}` : 'OWASP: downloading NVD database (no cache or update forced)');
-    !cmd.quick && await run(`mvn org.owasp:dependency-check-maven:check ${owaspArgs}`, { throw: false });
+    // Keep version in sync with .github/workflows/sbom.yml and .github/workflows/update-nvd-db.yml — NVD cache schema must match.
+    !cmd.quick && await run(`mvn org.owasp:dependency-check-maven:12.2.2:check ${owaspArgs}`, { throw: false });
     sumarizeOWASP('target/dependency-check-report.json', vulnerabilities);
   }
 


### PR DESCRIPTION
- Update action tools version to get rid of the node 24 warning
- Replacing thollander with a gh Bash step that mimics the upsert-by-tag behavior using an HTML-comment marker.                                    
- pin the `dependency-check` version in sbom scripts to provent the inconsistence as  
```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:12.2.2:check (default-cli) on project vaadin-platform-sbom: Fatal exception(s) analyzing vaadin-platform-sbom: One or more exceptions occurred during analysis:
[ERROR] 	DatabaseException: Unable to connect to the dependency-check database
Error:  		caused by DatabaseException: Database schema does not match this version of dependency-check
[ERROR] 		caused by DatabaseException: Old database schema identified - please execute dependency-check without the no-update configuration to continue
```