### PR TITLE
chore: remove badge and master-detail-layout feature flags

### DIFF
--- a/scripts/generator/templates/template-dev-bundle-pom.xml
+++ b/scripts/generator/templates/template-dev-bundle-pom.xml
@@ -54,14 +54,16 @@
         <!--
             vaadin-hybrid-dev-bundle must be a project dependency otherwise it will be built
             after vaadin-dev-bundle because of modules configuration in root pom.
-            Configuring the dependency with provided scope will prevent it to be scanned by
-            flow-dev-bundle-plugin.
+             Configuring the dependency with test scope keeps the reactor ordering but prevents
+            flow-dev-bundle-plugin from finding the embedded reference dev-bundle on its
+            classpath (the plugin scans compile/runtime/system/provided scopes, not test),
+            so the local dev-bundle build is always performed instead of being skipped.
         -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>vaadin-hybrid-dev-bundle</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,8 +1,4 @@
-# Master Detail Layout Component (Experimental)
-com.vaadin.experimental.masterDetailLayoutComponent=true
 
 # Slider Component (Experimental)
 com.vaadin.experimental.sliderComponent=true
 
-# Badge Component (Experimental)
-com.vaadin.experimental.badgeComponent=true

--- a/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
@@ -1,8 +1,2 @@
-# Master Detail Layout Component (Experimental)
-com.vaadin.experimental.masterDetailLayoutComponent=true
-
 # Slider Component (Experimental)
 com.vaadin.experimental.sliderComponent=true
-
-# Badge Component (Experimental)
-com.vaadin.experimental.badgeComponent=true

--- a/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,8 +1,2 @@
-# Master Detail Layout Component (Experimental)
-com.vaadin.experimental.masterDetailLayoutComponent=true
-
 # Slider Component (Experimental)
 com.vaadin.experimental.sliderComponent=true
-
-# Badge Component (Experimental)
-com.vaadin.experimental.badgeComponent=true

--- a/versions.json
+++ b/versions.json
@@ -119,7 +119,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "25.2.0-alpha13"
+            "javaVersion": "25.2-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "16.0.1"
@@ -138,7 +138,7 @@
             "npmName": "@vaadin/grid"
         },
         "hilla": {
-            "javaVersion": "25.2.0-alpha9"
+            "javaVersion": "25.2-SNAPSHOT"
         },
         "horizontal-layout": {
             "jsVersion": "25.2.0-alpha13",


### PR DESCRIPTION
## Description

These components will become stable in 25.2 so let's remove feature flags (WC and FC already updated).
Slider will be also removed in WC beta1 but it also needs Flow component PR, so I'll update it separately.

## Type of change

- Internal change