### PR TITLE
chore: upgrade gradle plugin-publish to 1.x 

### DIFF
--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'idea'
-    id 'com.gradle.plugin-publish' version '0.11.0'
+    id 'com.gradle.plugin-publish' version '1.3.1'
     id 'org.jetbrains.kotlin.jvm' version '2.1.21'
     id 'org.jetbrains.dokka' version '1.8.20'
 }
@@ -43,9 +43,13 @@ configurations {
     functionalTestImplementation.extendsFrom testImplementation
 }
 
-task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
+// The plugin-publish plugin (1.x) automatically registers `sourcesJar` and
+// `javadocJar` tasks and includes their output in the published plugin
+// artifacts. Package the Dokka-generated API documentation into the javadoc
+// jar so the published javadoc reflects the Kotlin sources.
+tasks.matching { it.name == 'javadocJar' }.configureEach {
+    dependsOn dokkaJavadoc
+    from dokkaJavadoc.outputDirectory
 }
 
 /***********************************************************************************************************************
@@ -97,25 +101,6 @@ jar {
     }
 }
 
-/**
- * Plugin artifact sources.
- */
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allSource
-    archiveClassifier = 'sources'
-    include 'com/**/*.groovy'
-    include 'com/**/*.java'
-    include 'com/**/*.kt'
-}
-
-/**
- * Artifacts in build
- */
-artifacts {
-    archives jar
-    archives sourcesJar
-}
-
 /***********************************************************************************************************************
  *
  * Testing & Quality
@@ -140,42 +125,24 @@ check.dependsOn functionalTest
  * Deployment
  *
  ***********************************************************************************************************************/
+// As of plugin-publish 1.x the bundle metadata (website, vcsUrl, display name,
+// description, tags) lives directly in the gradlePlugin block; the separate
+// pluginBundle block has been removed. The plugin also auto-applies
+// java-gradle-plugin and maven-publish and creates a single `pluginMaven`
+// publication (jar + sources + javadoc) used by publishPlugins, so no manual
+// MavenPublication is declared here.
 gradlePlugin {
+    website = 'https://vaadin.com/docs/latest/guide/start/gradle'
+    vcsUrl = 'https://github.com/vaadin/flow'
     testSourceSets sourceSets.functionalTest
     plugins {
         vaadinPlugin {
             id = 'com.vaadin'
             implementationClass = 'com.vaadin.gradle.plugin.VaadinPlugin'
-        }
-    }
-}
-
-pluginBundle {
-    website = 'https://vaadin.com/docs/latest/guide/start/gradle'
-    vcsUrl = 'https://github.com/vaadin/flow'
-    description = 'Build Vaadin applications with Gradle. As of Vaadin 20+, the gradle plugin is released as part of the Vaadin Platform with the same version. ' +
-            'For older versions, please follow the link below to learn which Plugin version to use with particular Vaadin version. Vaadin recommends using the latest Vaadin LTS version.'
-    tags = ['vaadin']
-    plugins {
-        vaadinPlugin {
-            id = gradlePlugin.plugins.vaadinPlugin.id
             displayName = 'Vaadin Gradle Plugin'
-        }
-    }
-    mavenCoordinates {
-        groupId = project.group
-        artifactId = project.archivesBaseName
-    }
-}
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = project.group
-            artifactId = project.archivesBaseName
-            version = project.version
-
-            from components.java
+            description = 'Build Vaadin applications with Gradle. As of Vaadin 20+, the gradle plugin is released as part of the Vaadin Platform with the same version. ' +
+                    'For older versions, please follow the link below to learn which Plugin version to use with particular Vaadin version. Vaadin recommends using the latest Vaadin LTS version.'
+            tags.set(['vaadin'])
         }
     }
 }


### PR DESCRIPTION
 1. com.gradle.plugin-publish 0.11.0 → 1.3.1
  2. javadocJar task replaced with the tasks.matching { … }.configureEach { … } form using dokkaJavadoc.outputDirectory
  3. Removed the manual sourcesJar task and artifacts block (the 1.x plugin auto-registers them)
  4. Merged pluginBundle + publishing into the single gradlePlugin block — metadata (website, vcsUrl, displayName, description, tags.set([...]))
  now lives inside the vaadinPlugin declaration; the manual MavenPublication is gone (the plugin creates the pluginMaven publication)
