### PR TITLE
fix duplicated jar for gradle plugin deployment

### DIFF
--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -105,10 +105,16 @@ task sourcesJar(type: Jar) {
 }
 
 /**
- * Artifacts in build
+ * Artifacts in build.
+ *
+ * Note: do NOT add `jar` here. The base plugin already registers the main jar
+ * in the `archives` configuration, and adding it again makes it appear twice.
+ * The Gradle Plugin Portal now rejects publishing the same artifact (JAR) more
+ * than once. Upgrading com.gradle.plugin-publish to 1.x (as on main, see
+ * e66fb0b4) is the long-term fix, but 1.x drops Gradle 7 support, so on this
+ * branch we keep 0.11.0 and only register the extra sources jar.
  */
 artifacts {
-    archives jar
     archives sourcesJar
 }
 


### PR DESCRIPTION
recently, gradle portal has updated their server to deny the deployment with multiple jars using the same name.
```
Execution failed for task ':publishPlugins'. java.lang.RuntimeException: Failed to post to server.                                                                                                                               
    Server responded with:                                                                                                                                                                                                         
    The same artifact (JAR) is being published more than once, which is no longer supported. Most likely, this is caused by an outdated version of the Plugin Publishing plugin. Please upgrade the 'com.gradle.plugin-publish' plugin to at least version 1.1.0 and publish again.        
```
 
in other branches, we have updated the publish plugin to 1.1.x  which is compatible with Gradle 8.x 

Vaadin 23.6 is using Gradle 7.x, so we need to fix the duplicated jars by ourselves. :-) 

the fix has been tested with our release build (23.6.0-alpha0)