### PR TITLE
chore: remove no longer needed slider component feature flag

### DIFF
--- a/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-dev-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,4 +1,0 @@
-
-# Slider Component (Experimental)
-com.vaadin.experimental.sliderComponent=true
-

--- a/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-platform-test/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,0 @@
-# Slider Component (Experimental)
-com.vaadin.experimental.sliderComponent=true

--- a/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
+++ b/vaadin-prod-bundle/src/main/resources/vaadin-featureflags.properties
@@ -1,2 +1,0 @@
-# Slider Component (Experimental)
-com.vaadin.experimental.sliderComponent=true


### PR DESCRIPTION
## Description

Slider becomes stable in 25.2 and the feature flag was removed in https://github.com/vaadin/flow-components/pull/9340.

## Type of change

- Internal change