### PR TITLE
Pin Flow version in prod bundle via flow-bom import

### DIFF
--- a/scripts/generator/templates/template-prod-bundle-pom.xml
+++ b/scripts/generator/templates/template-prod-bundle-pom.xml
@@ -29,6 +29,13 @@
         <dependencies>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>flow-bom</artifactId>
+                <version>${flow.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-components-bom</artifactId>
                 <version>${flow.components.version}</version>
                 <type>pom</type>


### PR DESCRIPTION
## Summary

The `vaadin-prod-bundle` module only imported `flow-components-bom`, which pulls the Flow artifacts (`flow-server`, `flow-react`, ...) at the platform snapshot version instead of the released Flow version used by `flow-maven-plugin`. This mismatch let the generated prod bundle drift with the Flow snapshot and broke `AllComponentsIncludedTest.compareStatsWithUnoptimized` (React Router files ending up in the non optimized bundle only).

Importing `flow-bom` at `${flow.version}` before `flow-components-bom` pins the Flow modules to the plugin's Flow version, matching what the dev bundle template already does. Verified on a clean checkout: the test passes 2/2 with a forced production rebuild.

## Context

Fixes the `Vaadin Flow used in project does not match the version expected by the Vaadin plugin` warning for the prod bundle.