### PR TITLE
chore: pin vaadin-themable-mixin in versions.json (25.2)

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -354,6 +354,11 @@
             "npmName": "@vaadin/router",
             "releasenotes": true
         },
+        "vaadin-themable-mixin": {
+            "jsVersion": "25.2.3",
+            "mode": "lit",
+            "npmName": "@vaadin/vaadin-themable-mixin"
+        },
         "vaadin-usage-statistics": {
             "jsVersion": "2.1.3",
             "npmName": "@vaadin/vaadin-usage-statistics"


### PR DESCRIPTION
## Summary

Add a `vaadin-themable-mixin` entry to the `core` section of `versions.json`, pinning `@vaadin/vaadin-themable-mixin` to 25.2.0 alongside its sibling base packages (`@vaadin/component-base`, `@vaadin/a11y-base`, `@vaadin/overlay`), which are already listed there.

## Context

`@vaadin/vaadin-themable-mixin` was the only core base web component package missing from `versions.json`, so it was left unpinned. This aligns it with the convention of listing all components. The entry is placed in the `core` section so it is emitted into `vaadin-core-versions.json`.

This is a consistency change. It is not the fix for the breadcrumbs bundle failure on 25.2, which is being addressed separately by backporting the Breadcrumbs React wrappers to the `@vaadin/react-components` 25.2 branch.