### PR TITLE
Depend on internal artifacts instead of the umbrella artifacts

### DIFF
--- a/vaadin-core-jandex/pom.xml
+++ b/vaadin-core-jandex/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
+            <artifactId>vaadin-core-internal</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <!-- Potentially optional dependencies according to online documentation -->

--- a/vaadin-jandex/pom.xml
+++ b/vaadin-jandex/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin</artifactId>
+            <artifactId>vaadin-internal</artifactId>
             <version>${project.version}</version>
             <exclusions>
                 <!-- Potentially optional dependencies according to online documentation -->

--- a/vaadin-quarkus/vaadin-quarkus-extension/pom.xml
+++ b/vaadin-quarkus/vaadin-quarkus-extension/pom.xml
@@ -64,7 +64,8 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
+            <artifactId>vaadin-core-internal</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-spring-boot-starter/pom.xml
+++ b/vaadin-spring-boot-starter/pom.xml
@@ -51,7 +51,8 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-core</artifactId>
+            <artifactId>vaadin-core-internal</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Spring -->


### PR DESCRIPTION
## Summary

`vaadin-jandex`, `vaadin-core-jandex`, `vaadin-spring-boot-starter` and the `vaadin-quarkus` extension depended on the `vaadin` and `vaadin-core` umbrella artifacts. They now depend on `vaadin-internal` and `vaadin-core-internal`, which provide the same classes at runtime (the umbrellas add no runtime dependencies over the internals). `vaadin-spring-boot-starter` and the quarkus extension get an explicit `${project.version}`, since `vaadin-core-internal` is not managed by the imported BOMs.

## Context

This leaves `vaadin` and `vaadin-core` as leaf artifacts that no other module in the build depends on. That lets the release publish the rest of the platform (including `vaadin-ee`) first and publish `vaadin` and `vaadin-core` in a later pass, without leaving any published artifact with an unresolvable dependency in between. It also matches how `vaadin-ee` already builds, using the internal artifacts.

Verified locally: `vaadin-jandex`, `vaadin-core-jandex`, `vaadin-spring-boot-starter` and the quarkus extension build and pass the enforcer.