### PR TITLE
chore: pin vaadin-themable-mixin in versions.json

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -354,6 +354,11 @@
             "npmName": "@vaadin/router",
             "releasenotes": true
         },
+        "vaadin-themable-mixin": {
+            "jsVersion": "25.3.0-alpha3",
+            "mode": "lit",
+            "npmName": "@vaadin/vaadin-themable-mixin"
+        },
         "vaadin-usage-statistics": {
             "jsVersion": "2.1.3",
             "npmName": "@vaadin/vaadin-usage-statistics"


### PR DESCRIPTION
## Description

Same as https://github.com/vaadin/platform/pull/9109 but for `main` branch.

Versions are pinned during alpha / beta stage, but once we enter stable this can be a problem again.

## Type of change

- Internal change