### PR TITLE
Stabilize ComponentsIT against slow app load

### DIFF
--- a/vaadin-platform-test/pom.xml
+++ b/vaadin-platform-test/pom.xml
@@ -240,6 +240,8 @@
                         </executions>
                         <configuration>
                             <forkCount>2</forkCount>
+                            <!-- Retry flaky browser tests (e.g. slow app load) before failing the build -->
+                            <rerunFailingTestsCount>2</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -66,7 +66,10 @@ public class ComponentsIT extends AbstractPlatformTest {
 
     @Test
     public void appWorks() throws Exception {
-        $(NotificationElement.class).waitForFirst();
+        // Wait for the app to finish loading and show the first notification.
+        // The default 10s can be too short when the CI agent or the frontend
+        // bundle is slow to serve, causing spurious timeouts, so wait longer.
+        waitUntil(driver -> $(NotificationElement.class).exists(), 30);
 
         new ComponentUsageTest().getTestComponents().forEach(this::checkElement);
     }


### PR DESCRIPTION
## Summary

`ComponentsIT.appWorks` fails intermittently (on different browsers each run, across unrelated PRs) with a Selenium timeout at the first wait (`ComponentsIT.java:69`), while the error screenshots show the app still on the Vaadin loading indicator with blank content. The app just did not finish loading within the default 10s TestBench timeout.

Two changes:
1. Wait up to 30s for the initial notification instead of the default 10s, so a slow app load under CI load does not cause a spurious timeout.
2. Add `rerunFailingTestsCount` to the failsafe configuration so a flaky browser test is retried before failing the build.

## Context

The failure is not tied to any specific component or code change: it is the initial app load timing out under CI load. These changes make the browser test tolerant of that.