### PR TITLE
Allow selecting the tested browsers with -Dgrid.browsers on the hub

### DIFF
--- a/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
+++ b/vaadin-platform-test/src/test/java/com/vaadin/platform/test/ComponentsIT.java
@@ -25,14 +25,19 @@ import com.vaadin.testbench.parallel.SauceLabsIntegration;
 public class ComponentsIT extends AbstractPlatformTest {
 
     static {
-        if (SauceLabsIntegration.isConfiguredForSauceLabs()) {
+        // Run on a grid when using Sauce Labs or a Selenium hub. The browser
+        // set can be overridden from CI with -Dgrid.browsers=... (comma
+        // separated), e.g. to exclude browsers that are flaky on the grid.
+        boolean onGrid = SauceLabsIntegration.isConfiguredForSauceLabs()
+                || System.getProperty(
+                        "com.vaadin.testbench.Parameters.hubHostname") != null;
+        if (onGrid) {
             String browsers = System.getProperty("grid.browsers");
             if (browsers == null || browsers.isEmpty()) {
-                // supported broswers : firefox esr is 128
-                Parameters.setGridBrowsers("firefox,firefox-128,safari-17,edge");
-            } else {
-                Parameters.setGridBrowsers(browsers);
+                // supported browsers : firefox esr is 128
+                browsers = "firefox,firefox-128,safari-17,edge";
             }
+            Parameters.setGridBrowsers(browsers);
         }
     }
 


### PR DESCRIPTION
## Summary

The `grid.browsers` system property was only read when running `ComponentsIT` against Sauce Labs. This makes it also apply when running against a Selenium hub (`com.vaadin.testbench.Parameters.hubHostname` set), so the browser set can be chosen from CI.

The default set (`firefox,firefox-128,safari-17,edge`) is unchanged when the property is not provided, so current behavior is preserved.

## Context

TeamCity PR validation runs these tests on the internal hub, where the property was previously ignored. With this change TeamCity can pass, for example, `-Dgrid.browsers=firefox-128,edge` to exclude browsers that are currently flaky on the grid, without touching the code or the Sauce runs.