### PR TITLE
chore: align kotlin and dokka versions with flow (CP: 25.2) (#9133)

### DIFF
--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -8,8 +8,8 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '1.3.1'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.21'
-    id 'org.jetbrains.dokka' version '1.8.20'
+    id 'org.jetbrains.kotlin.jvm' version '2.4.0'
+    id 'org.jetbrains.dokka' version '1.9.20'
 }
 
 /***********************************************************************************************************************
@@ -67,14 +67,14 @@ repositories {
 }
 
 dependencies {
-    implementation('org.jetbrains.kotlin:kotlin-stdlib:2.1.21')
+    implementation('org.jetbrains.kotlin:kotlin-stdlib:2.4.0')
     implementation("com.vaadin:hilla-engine-core:${pom.properties.getAt('hilla.version')}")
     implementation("com.vaadin:flow-gradle-plugin:${pom.properties.getAt('flow.version')}")
     implementation("com.vaadin:flow-plugin-base:${pom.properties.getAt('flow.version')}")
     implementation("com.vaadin:vaadin-prod-bundle:${project.version}")
     implementation("com.vaadin:vaadin-dev-bundle:${project.version}")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:2.1.21")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:2.4.0")
 }
 
 idea {


### PR DESCRIPTION
Manual cherry-pick of the build.gradle part of #9133 to 25.2.

Flow 25.2 publishes flow-gradle-plugin compiled with Kotlin 2.4.0 since vaadin/flow#24904 (merged Jul 3). The vaadin-gradle-plugin on this branch still compiles with Kotlin 2.1.21, which cannot read Kotlin 2.4.0 metadata, so the platform snapshot build fails at the gradle plugin step since Jul 3.

The versions.json hunk of the original commit (flow 25.3.0-alpha3) does not apply to this branch, which is why the automated cherry-pick reported a conflict.