### PR TITLE
chore: bump copilot to 25.2.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -382,7 +382,7 @@
             "version": "1.0.0"
         },
         "copilot": {
-            "javaVersion": "25.2.1"
+            "javaVersion": "25.2.2"
         },
         "kubernetes-kit-starter": {
             "javaVersion": "3.1.1"


### PR DESCRIPTION
## Summary

Bump the `copilot` version in `versions.json` from 25.2.1 to 25.2.2 for the 25.2.2 platform release. `com.vaadin:copilot:25.2.2` is published and was built against flow-components 25.2.2 (and flow 25.2.1, matching the platform stack).

Only `copilot` is changed; flow and hilla stay at 25.2.1 (hilla 25.2.2 is not released) and the web components remain at their pinned versions.