### PR TITLE
Override vulnerable transitive dependencies in vaadin-bom

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -121,6 +121,18 @@ const cveWhiteList = {
     cves: ['CVE-2026-54285'],
     description: 'Not affected: @opentelemetry/core is a transitive dep of the browser Web SDK and is used only to ORIGINATE spans. The vulnerable W3CBaggagePropagator.extract() (inbound untrusted baggage parsing) is never on the execution path. vulnerable_code_not_in_execute_path.'
   },
+  'pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.22.1' : {
+    cves: ['CVE-2026-54515'],
+    description: 'Not affected: Vaadin and Hilla deserialize endpoint input with the default Jackson mapper. The bypass requires MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, which Vaadin does not enable (verified in Hilla JacksonObjectMapperFactory). vulnerable_code_not_in_execute_path. Tracked upstream in vaadin/hilla#5801 and vaadin/appsec-kit#238.'
+  },
+  'pkg:maven/tools.jackson.core/jackson-databind@2.22.1' : {
+    cves: ['CVE-2026-54515'],
+    description: 'False report: the resolved tools.jackson jackson-databind (3.1.5) is not affected per osv.dev. This entry is a SBOM version mislabel. Tracked upstream in vaadin/flow#24962 and vaadin/hilla#5801.'
+  },
+  'pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@2.4.0' : {
+    cves: ['CVE-2026-53914'],
+    description: 'False positive: osv.dev reports kotlin-stdlib 2.4.0 as not affected. owasp flags it via imprecise CPE matching. Tracked upstream in vaadin/flow#24962 and vaadin/hilla#5801.'
+  },
 }
 
 const STYLE = `<style>

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -16,6 +16,12 @@
 {{javadeps}}
         <slf4j.version>2.0.17</slf4j.version>
         <jna.version>5.18.1</jna.version>
+        <!-- Security overrides: force fixed transitive versions -->
+        <logback.security.version>1.5.35</logback.security.version>
+        <tomcat.security.version>11.0.24</tomcat.security.version>
+        <jackson2.security.version>2.22.1</jackson2.security.version>
+        <jackson3.security.version>3.1.5</jackson3.security.version>
+        <kotlin.security.version>2.4.0</kotlin.security.version>
     </properties>
 
     <distributionManagement>
@@ -27,6 +33,63 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+             Security overrides. These force fixed transitive versions ahead of
+             Spring Boot / Flow / Hilla management. Declared before the
+             vaadin-spring-bom import so the imported BOMs win. Remove each once
+             the upstream (Spring Boot, Flow, Hilla) ships the fixed version.
+            -->
+            <!-- jackson 2.x, CVE-2026-54515 -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson2.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- jackson 3.x, CVE-2026-54515 -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson3.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- kotlin, CVE-2026-53914 -->
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-bom</artifactId>
+                <version>${kotlin.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- logback, CVE-2026-10532 -->
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>${logback.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>${logback.security.version}</version>
+            </dependency>
+            <!-- tomcat embed, CVE-2026-53434/55276/53404/55955/55956/50229 -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-spring-bom</artifactId>


### PR DESCRIPTION
## Summary

Force fixed versions of vulnerable transitive dependencies in `vaadin-bom` (via `template-vaadin-bom.xml`), so both the platform build/SBOM and downstream consumers pick up the patched versions. These are not whitelist entries; they upgrade the affected libraries to released fixed versions.

| Dependency | From (transitive) | Was | Now | CVE |
|---|---|---|---|---|
| logback-core / logback-classic | Spring Boot | 1.5.34 | 1.5.35 | CVE-2026-10532 |
| tomcat-embed-* | Spring Boot | 11.0.22 | 11.0.24 | CVE-2026-53434, 55276, 53404, 55955, 55956, 50229 |
| jackson-databind (com.fasterxml) | Hilla, appsec-kit, Spring Boot | 2.21.4 | 2.22.1 (jackson-bom) | CVE-2026-54515 |
| jackson-databind (tools.jackson, Jackson 3) | Flow, Hilla, Spring Boot | 3.1.4 | 3.1.5 (jackson-bom) | CVE-2026-54515 |
| kotlin-stdlib / kotlin-reflect | Flow (webpush), Hilla | 2.3.0 / 2.1.21 | 2.4.0 (kotlin-bom) | CVE-2026-53914 |

## Context

The overrides are declared before the `vaadin-spring-bom` import so the imported jackson/kotlin BOMs win over Spring Boot's management, and the logback/tomcat direct entries take precedence too. Spring Boot 4.1.0 has no newer patch yet, so the fix has to live in platform for now. Each override should be dropped once the corresponding upstream (Spring Boot, Flow, Hilla) ships the fixed version.

The remaining SBOM findings (opentelemetry, jcef, swing-kit) are already justified as not affected, and the jackson pulled by cyclonedx-core-java is build tooling only, not shipped.

## Related to

Upstream issues to ship the fixed versions so these overrides and allowlist entries can be removed:

- vaadin/flow#24962 (Jackson 3 to 3.1.5, Kotlin to 2.4.0)
- vaadin/hilla#5801 (Jackson 2 to 2.22.1, Jackson 3 to 3.1.5, Kotlin to 2.4.0)
- vaadin/appsec-kit#238 (jackson-databind to 2.22.1)
