### PR TITLE
chore: align kotlin and dokka versions with flow (#9133) (CP: 25.1)

### DIFF
--- a/vaadin-gradle-plugin/build.gradle
+++ b/vaadin-gradle-plugin/build.gradle
@@ -8,8 +8,8 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'com.gradle.plugin-publish' version '1.3.1'
-    id 'org.jetbrains.kotlin.jvm' version '2.1.21'
-    id 'org.jetbrains.dokka' version '1.8.20'
+    id 'org.jetbrains.kotlin.jvm' version '2.4.0'
+    id 'org.jetbrains.dokka' version '1.9.20'
 }
 
 /***********************************************************************************************************************
@@ -67,14 +67,14 @@ repositories {
 }
 
 dependencies {
-    implementation('org.jetbrains.kotlin:kotlin-stdlib:2.1.21')
+    implementation('org.jetbrains.kotlin:kotlin-stdlib:2.4.0')
     implementation("com.vaadin:hilla-engine-core:${pom.properties.getAt('hilla.version')}")
     implementation("com.vaadin:flow-gradle-plugin:${pom.properties.getAt('flow.version')}")
     implementation("com.vaadin:flow-plugin-base:${pom.properties.getAt('flow.version')}")
     implementation("com.vaadin:vaadin-prod-bundle:${project.version}")
     implementation("com.vaadin:vaadin-dev-bundle:${project.version}")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:2.1.21")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:2.4.0")
 }
 
 idea {

--- a/versions.json
+++ b/versions.json
@@ -1,37 +1,37 @@
 {
     "core": {
         "a11y-base": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/a11y-base"
         },
         "accordion": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/accordion"
         },
         "app-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/app-layout"
         },
         "aura": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/aura"
         },
         "avatar": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/avatar"
         },
         "avatar-group": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/avatar-group"
         },
         "badge": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/badge"
         },
@@ -39,82 +39,82 @@
             "javaVersion": "1.0.0"
         },
         "button": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/button"
         },
         "card": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/card"
         },
         "checkbox": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/checkbox"
         },
         "checkbox-group": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/checkbox-group"
         },
         "combo-box": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/combo-box"
         },
         "component-base": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/component-base"
         },
         "confirm-dialog": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/confirm-dialog"
         },
         "context-menu": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/context-menu"
         },
         "custom-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/custom-field"
         },
         "date-picker": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/date-picker"
         },
         "date-time-picker": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/date-time-picker"
         },
         "details": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/details"
         },
         "dialog": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/dialog"
         },
         "email-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/email-field"
         },
         "field-base": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/field-base"
         },
         "field-highlighter": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/field-highlighter"
         },
@@ -128,12 +128,12 @@
             "javaVersion": "{{version}}"
         },
         "form-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/form-layout"
         },
         "grid": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/grid"
         },
@@ -141,72 +141,72 @@
             "javaVersion": "25.1.7"
         },
         "horizontal-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/horizontal-layout"
         },
         "icon": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/icon"
         },
         "icons": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/icons"
         },
         "input-container": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/input-container"
         },
         "integer-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/integer-field"
         },
         "item": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/item"
         },
         "list-box": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/list-box"
         },
         "lit-renderer": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/lit-renderer"
         },
         "login": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/login"
         },
         "markdown": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/markdown"
         },
         "master-detail-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/master-detail-layout"
         },
         "menu-bar": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/menu-bar"
         },
         "message-input": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/message-input"
         },
         "message-list": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/message-list"
         },
@@ -217,102 +217,102 @@
             "javaVersion": "8.0.1"
         },
         "multi-select-combo-box": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/multi-select-combo-box"
         },
         "notification": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/notification"
         },
         "number-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/number-field"
         },
         "overlay": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/overlay"
         },
         "password-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/password-field"
         },
         "popover": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/popover"
         },
         "progress-bar": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/progress-bar"
         },
         "radio-group": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/radio-group"
         },
         "scroller": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/scroller"
         },
         "select": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/select"
         },
         "side-nav": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/side-nav"
         },
         "slider": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/slider"
         },
         "split-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/split-layout"
         },
         "tabs": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/tabs"
         },
         "tabsheet": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/tabsheet"
         },
         "text-area": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/text-area"
         },
         "text-field": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/text-field"
         },
         "time-picker": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/time-picker"
         },
         "tooltip": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/tooltip"
         },
         "upload": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/upload"
         },
@@ -324,7 +324,7 @@
             "npmName": "@vaadin/vaadin-development-mode-detector"
         },
         "vaadin-lumo-styles": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/vaadin-lumo-styles",
             "releasenotes": true
@@ -350,7 +350,7 @@
             "releasenotes": true
         },
         "vaadin-themable-mixin": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/vaadin-themable-mixin"
         },
@@ -359,12 +359,12 @@
             "npmName": "@vaadin/vaadin-usage-statistics"
         },
         "vertical-layout": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/vertical-layout"
         },
         "virtual-list": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/virtual-list"
         }
@@ -460,7 +460,7 @@
                 "@vaadin/vertical-layout",
                 "@vaadin/virtual-list"
             ],
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "react",
             "npmName": "@vaadin/react-components"
         },
@@ -474,44 +474,44 @@
                 "@vaadin/map",
                 "@vaadin/rich-text-editor"
             ],
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "react",
             "npmName": "@vaadin/react-components-pro"
         }
     },
     "vaadin": {
         "board": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/board"
         },
         "charts": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/charts"
         },
         "crud": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/crud"
         },
         "dashboard": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/dashboard"
         },
         "grid-pro": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/grid-pro"
         },
         "map": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/map"
         },
         "rich-text-editor": {
-            "jsVersion": "25.1.6",
+            "jsVersion": "25.1.7",
             "mode": "lit",
             "npmName": "@vaadin/rich-text-editor"
         },

--- a/versions.json
+++ b/versions.json
@@ -119,7 +119,7 @@
             "npmName": "@vaadin/field-highlighter"
         },
         "flow": {
-            "javaVersion": "25.1.11"
+            "javaVersion": "25.1-SNAPSHOT"
         },
         "flow-cdi": {
             "javaVersion": "16.0.2"


### PR DESCRIPTION
Flow 25.1 ships flow-gradle-plugin compiled with Kotlin 2.4.0 since vaadin/flow#24905, which the previous Kotlin 2.1.21 compiler cannot read (metadata 2.4.0). Picks only the build.gradle part of #9133, the versions.json hunk does not apply to this branch.
