### PR TITLE
feat: report vaadin-ee usage in development mode

### DIFF
--- a/vaadin-ee/src/main/java/com/vaadin/platform/ee/EnterpriseEditionInitializer.java
+++ b/vaadin-ee/src/main/java/com/vaadin/platform/ee/EnterpriseEditionInitializer.java
@@ -12,6 +12,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.startup.BaseLicenseCheckerServiceInitListener;
@@ -52,6 +53,14 @@ public class EnterpriseEditionInitializer
             logEnterpriseBanner(version);
         } else {
             logNoLicenseBanner(version);
+        }
+
+        // Report that this application depends on Enterprise Edition. Usage
+        // statistics are gathered in development mode only (the client
+        // gatherer is stripped from production bundles), so there is nothing
+        // to report from production instances.
+        if (!productionMode) {
+            UsageStatistics.markAsUsed(PRODUCT_NAME, version);
         }
 
         // Delegate the real license handling (in dev mode this offers the trial


### PR DESCRIPTION
## Summary

Register `vaadin-ee` with the current platform version through `UsageStatistics.markAsUsed` when `EnterpriseEditionInitializer` runs, so Enterprise Edition adoption shows up in the usage statistics.

The entry is registered in development mode only, since usage statistics are gathered exclusively in development (the client gatherer is stripped from production bundles and production instances are not tracked in the collector DB).

## Context

The identifier `vaadin-ee` plus the platform version rides Flow's existing usage statistics pipeline, so it lands in the collector as a normal element entry with no changes needed on the ingestion side.