### PR TITLE
fix: parse module release links with a regex in the release note generator

### DIFF
--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -115,7 +115,13 @@ writer.writeReleaseNotes(versions, releaseNotesTemplateFileName, releaseNotesRes
 writer.writeReleaseNotes(versions, releaseNotesMaintenanceTemplateFileName, releaseNotesMaintenanceResultFileName);
 writer.writeReleaseNotes(versions, releaseNotesPrereleaseTemplateFileName, releaseNotesPrereleaseResultFileName);
 if(!versions.platform.includes('SNAPSHOT')){
-  writer.writeModulesReleaseNotes(versions, versions.platform, modulesReleaseNotesFileName, modulesReleaseNotesResultFileName);
+  // The modules release note is an optional documentation artifact built from the GitHub API.
+  // It must never abort the generation of the poms, which the SBOM and the release build need.
+  try {
+    writer.writeModulesReleaseNotes(versions, versions.platform, modulesReleaseNotesFileName, modulesReleaseNotesResultFileName);
+  } catch (error) {
+    console.warn(`Skipped ${modulesReleaseNotesResultFileName}: ${error.message}`);
+  }
 }
 
 writer.writeProperty(versions, ["flow","hilla"], mavenPluginTemplatePomFileName, mavenPluginResultPomFileName);

--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -341,32 +341,47 @@ function createModulesReleaseNotes(versions, version, modulesReleaseNoteTemplate
     return render(modulesReleaseNoteTemplate, modulesReleaseNoteData);
 }
 
+// Matches a module release link anywhere in the note body. The version stops at the first
+// ')', whitespace or CR so that neither the closing markdown paren nor the CR of a CRLF
+// body ends up in the version, which would later make the GitHub API path unusable.
+const MODULE_RELEASE_LINK_RE = /https:\/\/github\.com\/vaadin\/([A-Za-z0-9._-]+)\/releases\/tag\/([^)\s]+)/g;
+
+/**
+Extract the module release links of a platform release note body.
+
+@param {String} platformReleaseNoteBody body of the platform release note.
+@return {Array} objects with the repo name, the tag and the release url, in note order.
+*/
+function parseModuleReleaseLinks(platformReleaseNoteBody) {
+    const links = [];
+    let match;
+    MODULE_RELEASE_LINK_RE.lastIndex = 0;
+    while ((match = MODULE_RELEASE_LINK_RE.exec(platformReleaseNoteBody)) !== null) {
+        const name = match[1];
+        if (name === 'platform') {
+            continue;
+        }
+        links.push({ name: name, version: match[2], releaseUrl: match[0] });
+    }
+    return links;
+}
+
 function collectModules(platformReleaseNoteBody) {
     const modules = [];
     const seen = new Set();
-    platformReleaseNoteBody.split("\n").forEach(line => {
-        if (!(line.includes("https") && line.includes("tag") && !line.includes("platform"))) {
+    parseModuleReleaseLinks(platformReleaseNoteBody).forEach(link => {
+        const key = `${link.name}@${link.version}`;
+        if (seen.has(key)) {
             return;
         }
-        line.split("](").forEach(
-            l => l.split("))").filter(notes => notes.includes("https")).forEach(noteLink => {
-                const moduleName = getModuleName(noteLink);
-                const noteVersion = getReleaseNoteVersion(noteLink);
-                const key = `${moduleName}@${noteVersion}`;
-                if (seen.has(key)) {
-                    return;
-                }
-                seen.add(key);
-                const noteBody = getReleaseNoteBody(moduleName, noteVersion) || '';
-                modules.push({
-                    name: moduleName,
-                    version: noteVersion,
-                    releaseUrl: noteLink,
-                    body: noteBody,
-                    category: getCategoryForModule(moduleName),
-                });
-            })
-        );
+        seen.add(key);
+        modules.push({
+            name: link.name,
+            version: link.version,
+            releaseUrl: link.releaseUrl,
+            body: getReleaseNoteBody(link.name, link.version) || '',
+            category: getCategoryForModule(link.name),
+        });
     });
     return modules;
 }
@@ -478,14 +493,6 @@ function wrapNoisySections(body) {
 
 function stripInlineFormatting(text) {
     return text.replace(/[`*_]/g, '').trim();
-}
-
-function getModuleName(link){
-  return link.substring(link.lastIndexOf("/vaadin/") + "/vaadin/".length, link.lastIndexOf("/releases"));
-}
-
-function getReleaseNoteVersion(link){
-  return link.substring(link.lastIndexOf("releases/tag/") + "releases/tag/".length)
 }
 
 function getReleaseNoteBody(name, version){
@@ -861,3 +868,4 @@ exports.addProperty = addProperty;
 exports.generateChangesString = generateChangesString;
 exports.calculatePreviousVersion = calculatePreviousVersion;
 exports.createModulesReleaseNotes = createModulesReleaseNotes;
+exports.parseModuleReleaseLinks = parseModuleReleaseLinks;

--- a/scripts/generator/test/creatorTest.js
+++ b/scripts/generator/test/creatorTest.js
@@ -303,3 +303,63 @@ describe('Release notes creator', function () {
         expect(previousSnapshotVersion).to.equal('');
     });
 });
+
+describe('Module release link parser', function () {
+    it('should parse links written in the parenthesized format', function () {
+        const body = '- Flow ([24.10.9](https://github.com/vaadin/flow/releases/tag/24.10.9)) and Hilla ([24.10.7](https://github.com/vaadin/hilla/releases/tag/24.10.7))\n'
+            + '  - Web Components ([24.10.4](https://github.com/vaadin/web-components/releases/tag/v24.10.4))\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '24.10.9', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/24.10.9' },
+            { name: 'hilla', version: '24.10.7', releaseUrl: 'https://github.com/vaadin/hilla/releases/tag/24.10.7' },
+            { name: 'web-components', version: 'v24.10.4', releaseUrl: 'https://github.com/vaadin/web-components/releases/tag/v24.10.4' },
+        ]);
+    });
+
+    it('should parse links written in the arrow chain format', function () {
+        const body = '- **Flow**: [25.2.4](https://github.com/vaadin/flow/releases/tag/25.2.4) → [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '25.2.4', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.4' },
+            { name: 'flow', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should not leak carriage returns from CRLF bodies into the version', function () {
+        const body = '- **Flow**: [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should skip links pointing at the platform repository', function () {
+        const body = '## Changes since [25.2.3](https://github.com/vaadin/platform/releases/tag/25.2.3)\r\n'
+            + '- **Hilla**: [25.2.5](https://github.com/vaadin/hilla/releases/tag/25.2.5)\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'hilla', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/hilla/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should produce versions that are safe to use in a request path', function () {
+        const body = '- **Flow**: [25.2.4](https://github.com/vaadin/flow/releases/tag/25.2.4) → [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\r\n'
+            + '- Flow ([24.10.9](https://github.com/vaadin/flow/releases/tag/24.10.9))\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.have.length(3);
+        result.forEach(function (module) {
+            const path = `https://api.github.com/repos/vaadin/${module.name}/releases/tags/${module.version}`;
+            expect(path).to.match(/^[\x21-\x7e]+$/);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the release note generator crash that has been preventing the SBOM from being attached to platform releases.

`collectModules` extracted module release links by splitting the note body on `](` and `))`. That only worked while every link was wrapped in parentheses:

```
- Flow ([24.10.9](https://github.com/vaadin/flow/releases/tag/24.10.9))
```

Since the notes moved to the arrow chain format, each link ends with a single closing paren:

```
- **Flow**: [25.2.4](https://github.com/vaadin/flow/releases/tag/25.2.4) → [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)
```

`split("))")` no longer matches, so the extracted tag kept the trailing paren plus the `\r` of the CRLF body, producing paths like `.../releases/tags/25.2.5)\r` and `.../releases/tags/25.2.4) → [25.2.5`. Node rejects the CR with `ERR_UNESCAPED_CHARACTERS`, `generate.js` exits 1, and the maven plugin, javadoc, bundle and quarkus poms are never written.

Changes:

* Replace the split chain with `parseModuleReleaseLinks`, a regex based parser that stops the tag at the first paren or whitespace, so both the old and the new note format parse cleanly.
* Filter platform links by repo name instead of by line content. The old `!line.includes("platform")` check also dropped `multiplatform-runtime`, which is now included.
* Drop `getModuleName` and `getReleaseNoteVersion`, now unused.
* Guard `writeModulesReleaseNotes` in `generate.js` so an optional documentation artifact built from the GitHub API can no longer abort pom generation.

Verified against the live 25.2.5 release body: 16 links parsed, 0 invalid paths, where before all 15 were invalid. `node scripts/generator/generate.js --platform=25.2.5` now completes with exit 0 and writes every pom.

## Context

The SBOM workflow ran on every release but died in this step, so no `Software.Bill.Of.Materials.json` was uploaded. Affected releases: 25.2.1, 25.2.3, 25.2.4, 25.2.5, 25.1.7, 25.1.8, 25.1.9, 25.1.10, 25.0.12, 25.0.13.

This never showed up on pull requests because `createModulesReleaseNotes` first fetches the platform release by tag. On a PR that tag does not exist, so it returns early and the broken parser is never reached.

Needs backporting to 25.2, 25.1 and 25.0.