### PR TITLE
chore: use branch build scripts when regenerating the SBOM of a release tag

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -569,6 +569,12 @@ async function main() {
     if (tag) {
       log(`Checking out tag ${tag}`)
       await run(`git checkout ${tag}`, { debug: false });
+      // Tags are immutable, so a released tag keeps whatever build scripts it shipped with,
+      // including their bugs. Take the scripts from the branch and the versions.json from the
+      // tag, so that regenerating the SBOM of an old release uses the fixed tooling while the
+      // reported dependencies remain the ones that release actually shipped.
+      log(`Restoring scripts from ${prev.branch}`)
+      await run(`git checkout ${prev.branch} -- scripts/`, { debug: false });
     }
     onExit = async () => {
       await run(`git stash`, { debug: false, throw: false });

--- a/scripts/generator/generate.js
+++ b/scripts/generator/generate.js
@@ -115,7 +115,13 @@ writer.writeReleaseNotes(versions, releaseNotesTemplateFileName, releaseNotesRes
 writer.writeReleaseNotes(versions, releaseNotesMaintenanceTemplateFileName, releaseNotesMaintenanceResultFileName);
 writer.writeReleaseNotes(versions, releaseNotesPrereleaseTemplateFileName, releaseNotesPrereleaseResultFileName);
 if(!versions.platform.includes('SNAPSHOT')){
-  writer.writeModulesReleaseNotes(versions, versions.platform, modulesReleaseNotesFileName, modulesReleaseNotesResultFileName);
+  // The modules release note is an optional documentation artifact built from the GitHub API.
+  // It must never abort the generation of the poms, which the SBOM and the release build need.
+  try {
+    writer.writeModulesReleaseNotes(versions, versions.platform, modulesReleaseNotesFileName, modulesReleaseNotesResultFileName);
+  } catch (error) {
+    console.warn(`Skipped ${modulesReleaseNotesResultFileName}: ${error.message}`);
+  }
 }
 
 writer.writeProperty(versions, ["flow","hilla"], mavenPluginTemplatePomFileName, mavenPluginResultPomFileName);

--- a/scripts/generator/src/creator.js
+++ b/scripts/generator/src/creator.js
@@ -341,32 +341,47 @@ function createModulesReleaseNotes(versions, version, modulesReleaseNoteTemplate
     return render(modulesReleaseNoteTemplate, modulesReleaseNoteData);
 }
 
+// Matches a module release link anywhere in the note body. The version stops at the first
+// ')', whitespace or CR so that neither the closing markdown paren nor the CR of a CRLF
+// body ends up in the version, which would later make the GitHub API path unusable.
+const MODULE_RELEASE_LINK_RE = /https:\/\/github\.com\/vaadin\/([A-Za-z0-9._-]+)\/releases\/tag\/([^)\s]+)/g;
+
+/**
+Extract the module release links of a platform release note body.
+
+@param {String} platformReleaseNoteBody body of the platform release note.
+@return {Array} objects with the repo name, the tag and the release url, in note order.
+*/
+function parseModuleReleaseLinks(platformReleaseNoteBody) {
+    const links = [];
+    let match;
+    MODULE_RELEASE_LINK_RE.lastIndex = 0;
+    while ((match = MODULE_RELEASE_LINK_RE.exec(platformReleaseNoteBody)) !== null) {
+        const name = match[1];
+        if (name === 'platform') {
+            continue;
+        }
+        links.push({ name: name, version: match[2], releaseUrl: match[0] });
+    }
+    return links;
+}
+
 function collectModules(platformReleaseNoteBody) {
     const modules = [];
     const seen = new Set();
-    platformReleaseNoteBody.split("\n").forEach(line => {
-        if (!(line.includes("https") && line.includes("tag") && !line.includes("platform"))) {
+    parseModuleReleaseLinks(platformReleaseNoteBody).forEach(link => {
+        const key = `${link.name}@${link.version}`;
+        if (seen.has(key)) {
             return;
         }
-        line.split("](").forEach(
-            l => l.split("))").filter(notes => notes.includes("https")).forEach(noteLink => {
-                const moduleName = getModuleName(noteLink);
-                const noteVersion = getReleaseNoteVersion(noteLink);
-                const key = `${moduleName}@${noteVersion}`;
-                if (seen.has(key)) {
-                    return;
-                }
-                seen.add(key);
-                const noteBody = getReleaseNoteBody(moduleName, noteVersion) || '';
-                modules.push({
-                    name: moduleName,
-                    version: noteVersion,
-                    releaseUrl: noteLink,
-                    body: noteBody,
-                    category: getCategoryForModule(moduleName),
-                });
-            })
-        );
+        seen.add(key);
+        modules.push({
+            name: link.name,
+            version: link.version,
+            releaseUrl: link.releaseUrl,
+            body: getReleaseNoteBody(link.name, link.version) || '',
+            category: getCategoryForModule(link.name),
+        });
     });
     return modules;
 }
@@ -478,14 +493,6 @@ function wrapNoisySections(body) {
 
 function stripInlineFormatting(text) {
     return text.replace(/[`*_]/g, '').trim();
-}
-
-function getModuleName(link){
-  return link.substring(link.lastIndexOf("/vaadin/") + "/vaadin/".length, link.lastIndexOf("/releases"));
-}
-
-function getReleaseNoteVersion(link){
-  return link.substring(link.lastIndexOf("releases/tag/") + "releases/tag/".length)
 }
 
 function getReleaseNoteBody(name, version){
@@ -861,3 +868,4 @@ exports.addProperty = addProperty;
 exports.generateChangesString = generateChangesString;
 exports.calculatePreviousVersion = calculatePreviousVersion;
 exports.createModulesReleaseNotes = createModulesReleaseNotes;
+exports.parseModuleReleaseLinks = parseModuleReleaseLinks;

--- a/scripts/generator/test/creatorTest.js
+++ b/scripts/generator/test/creatorTest.js
@@ -303,3 +303,63 @@ describe('Release notes creator', function () {
         expect(previousSnapshotVersion).to.equal('');
     });
 });
+
+describe('Module release link parser', function () {
+    it('should parse links written in the parenthesized format', function () {
+        const body = '- Flow ([24.10.9](https://github.com/vaadin/flow/releases/tag/24.10.9)) and Hilla ([24.10.7](https://github.com/vaadin/hilla/releases/tag/24.10.7))\n'
+            + '  - Web Components ([24.10.4](https://github.com/vaadin/web-components/releases/tag/v24.10.4))\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '24.10.9', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/24.10.9' },
+            { name: 'hilla', version: '24.10.7', releaseUrl: 'https://github.com/vaadin/hilla/releases/tag/24.10.7' },
+            { name: 'web-components', version: 'v24.10.4', releaseUrl: 'https://github.com/vaadin/web-components/releases/tag/v24.10.4' },
+        ]);
+    });
+
+    it('should parse links written in the arrow chain format', function () {
+        const body = '- **Flow**: [25.2.4](https://github.com/vaadin/flow/releases/tag/25.2.4) → [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '25.2.4', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.4' },
+            { name: 'flow', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should not leak carriage returns from CRLF bodies into the version', function () {
+        const body = '- **Flow**: [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'flow', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/flow/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should skip links pointing at the platform repository', function () {
+        const body = '## Changes since [25.2.3](https://github.com/vaadin/platform/releases/tag/25.2.3)\r\n'
+            + '- **Hilla**: [25.2.5](https://github.com/vaadin/hilla/releases/tag/25.2.5)\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.deep.equal([
+            { name: 'hilla', version: '25.2.5', releaseUrl: 'https://github.com/vaadin/hilla/releases/tag/25.2.5' },
+        ]);
+    });
+
+    it('should produce versions that are safe to use in a request path', function () {
+        const body = '- **Flow**: [25.2.4](https://github.com/vaadin/flow/releases/tag/25.2.4) → [25.2.5](https://github.com/vaadin/flow/releases/tag/25.2.5)\r\n'
+            + '- Flow ([24.10.9](https://github.com/vaadin/flow/releases/tag/24.10.9))\r\n';
+
+        const result = creator.parseModuleReleaseLinks(body);
+
+        expect(result).to.have.length(3);
+        result.forEach(function (module) {
+            const path = `https://api.github.com/repos/vaadin/${module.name}/releases/tags/${module.version}`;
+            expect(path).to.match(/^[\x21-\x7e]+$/);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When `generateAndCheckSBOM.js` is given a `--version` that matches an existing release, it checks out the minor branch and then the release tag. Tags are immutable, so the run also gets the build scripts that release shipped with, including their bugs. That makes it impossible to regenerate the SBOM of a release whose build scripts were broken.

Restore `scripts/` from the minor branch after checking out the tag:

* `versions.json` still comes from the tag, so the reported dependencies remain the ones that release actually shipped.
* the tooling comes from the branch, so fixes to the generator apply to historical releases too.

Verified on tag 25.2.4, which currently fails: with `scripts/` restored from a branch carrying the generator fix, `node scripts/generator/generate.js --platform=25.2.4` completes with exit 0 and the generated `vaadin-core-versions.json` keeps the tag's own module versions (flow 25.2.5, web components 25.2.6), not the branch's.

## Context

Needed to backfill the `Software.Bill.Of.Materials.json` asset for 25.0.12, 25.0.13, 25.1.7 to 25.1.10, 25.2.1 and 25.2.3 to 25.2.5, whose SBOM workflow runs all died in the release note generator. Depends on #9254 and its cherry-picks to 25.0, 25.1 and 25.2, since the restored scripts are taken from those branches.