### PR TITLE
fix: include AI field marker in optimized prod bundle

### DIFF
--- a/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
+++ b/vaadin-prod-bundle/src/main/java/com/vaadin/prodbundle/EagerView.java
@@ -78,6 +78,7 @@ import com.vaadin.flow.router.Route;
 
 @Route
 @JsModule("@vaadin/tooltip/vaadin-tooltip.js")
+@JsModule("@vaadin/field-highlighter/src/vaadin-ai-field-marker.js")
 public class EagerView extends Div {
 
     public Accordion accordion;


### PR DESCRIPTION
flow-components#9868 added @JsModule("@vaadin/field-highlighter/src/ vaadin-ai-field-marker.js") on FormFieldMarker, a package-private class only reached via FormAIController. The unoptimized bundle picks it up through its full classpath scan, but the optimized bundle only collects modules reachable from the app's entry points, so the import was missing there and AllComponentsIncludedTest.compareStatsWithUnoptimized failed.

Declare the module on EagerView, as done for vaadin-tooltip.js — a field reference is not possible since FormFieldMarker is package-private.

