### PR TITLE
feat!: follow AI module split into core and extensions

### DIFF
--- a/vaadin-core-components/pom.xml
+++ b/vaadin-core-components/pom.xml
@@ -37,7 +37,7 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-ai-components-flow</artifactId>
+            <artifactId>vaadin-ai-core-flow</artifactId>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-internal/pom.xml
+++ b/vaadin-internal/pom.xml
@@ -39,6 +39,11 @@
 
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-ai-extensions-flow</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-board-flow</artifactId>
         </dependency>
 


### PR DESCRIPTION
## Summary
- vaadin/flow-components#9887 removed `vaadin-ai-components-flow`, so platform has to depend on its replacements or the build breaks.
- The split exists to license the AI controllers like other commercial products, so the free core module belongs in `vaadin-core-components` and the commercial extensions module in `vaadin-internal` — that way the extensions ship with `vaadin` and `vaadin-ee` but not with `vaadin-core`.
- No versions are declared, since `flow-components-bom` manages both new artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)