### PR TITLE
chore: update spring-ai and langchain4j versions used for javadoc generation

### DIFF
--- a/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
+++ b/scripts/generator/templates/template-vaadin-platform-javadoc-pom.xml
@@ -39,10 +39,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Manages the spring-ai artifacts used by the AI components. Keep in
+                 sync with the spring-ai version in vaadin-ai-core-flow. -->
             <dependency>
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-bom</artifactId>
-                <version>2.0.0-M2</version>
+                <version>2.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -310,11 +312,12 @@
                     <version>1.47.0</version>
                     <scope>provided</scope>
                 </dependency>
-                <!-- used in AI Components -->
+                <!-- Optional dependencies of the AI components, needed to resolve
+                     their public API when generating javadoc. -->
                 <dependency>
                     <groupId>dev.langchain4j</groupId>
                     <artifactId>langchain4j</artifactId>
-                    <version>1.11.0</version>
+                    <version>1.19.0</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
## Summary

Bump the AI dependencies pinned in the platform javadoc pom template to the versions the AI components are actually compiled against: `spring-ai-bom` 2.0.0 (was the 2.0.0-M2 milestone) and `langchain4j` 1.19.0 (was 1.11.0).

## Context

`vaadin-ai-core-flow` declares `spring-ai-client-chat`, `spring-ai-model` and `langchain4j` as optional dependencies. Optional dependencies are not transitive, so the javadoc module has to declare them itself, otherwise javadoc generation cannot resolve the public API of classes such as `SpringAILLMProvider` and `LangChain4JLLMProvider`. The versions were added when spring-ai was still a milestone and had drifted from the ones used by the components, so they are now aligned and a comment explains why the entries are there.

Verified locally by generating the javadoc pom and running `mvn -Pjavadocs javadoc:javadoc`: build succeeds and the AI provider classes are documented with their `ChatClient` and `ChatModel` signatures resolved.