### PR TITLE
fix: follow map connector rename to TypeScript in prod bundle test

### DIFF
--- a/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/AllComponentsIncludedTest.java
+++ b/vaadin-prod-bundle/src/test/java/com/vaadin/prodbundle/AllComponentsIncludedTest.java
@@ -31,7 +31,7 @@ public class AllComponentsIncludedTest {
             "@vaadin/map/src/vaadin-map.js",
             "@vaadin/rich-text-editor/src/vaadin-rich-text-editor.js",
             "@vaadin/vaadin-lumo-styles/vaadin-iconset.js",
-            "Frontend/generated/jar-resources/vaadin-map/mapConnector.js",
+            "Frontend/generated/jar-resources/vaadin-map/mapConnector.ts",
             "Frontend/generated/jar-resources/vaadin-map/synchronization/index.js",
             "Frontend/generated/jar-resources/vaadin-spreadsheet/spreadsheet-export.js",
             "Frontend/generated/jar-resources/vaadin-spreadsheet/vaadin-spreadsheet.js",


### PR DESCRIPTION
## Summary

Update the map connector file name in `AllComponentsIncludedTest.lazyComponentFiles` from `mapConnector.js` to `mapConnector.ts`.

## Context

vaadin/flow-components#9932 converted the remaining connector frontend files to TypeScript, so `vaadin-map-flow` now ships `META-INF/frontend/vaadin-map/mapConnector.ts`. The test lists the file names that belong to lazy loaded components by their literal name, so the renamed file stopped matching and the test started failing with:

```
'Frontend/generated/jar-resources/vaadin-map/mapConnector.ts' is included but not eagerly loaded.
```

This blocks every platform PR build, for example https://teamcity.vaadin.com/buildConfiguration/VaadinPlatform_VaadinPlatformPrValidation/358229. Reproduced on a clean clone of main with a forced prod bundle rebuild: the test fails before the change and passes after it. Only the map connector was renamed, the other entries in the list still ship as `.js`.