### PR TITLE
chore: update Spring Boot to 4.1.1 and acknowledge kotlin reports in SBOM check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.1.0</spring.boot.version>
+        <spring.boot.version>4.1.1</spring.boot.version>
         <jakarta.ee.version>11.0.0</jakarta.ee.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <jetty.version>12.0.22</jetty.version>

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -105,6 +105,14 @@ const cveWhiteList = {
     cves: ['CVE-2021-33604'],
     description: 'false report: this CVE is targeting Vaadin version prior 20, swing-kit-flow is using vaadin 24+ version, the related issue has been fixed.'
   },
+  'pkg:maven/org.jetbrains.kotlin/kotlin-reflect@2.4.0' : {
+    cves: ['CVE-2026-53914'],
+    description: 'FP: the report only affects org.jetbrains.kotlin:kotlin-gradle-plugin, the CPE for the kotlin product matches any kotlin artifact. We ship kotlin-reflect as a transitive dependency of the hilla typescript generator, not the gradle plugin.'
+  },
+  'pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@2.4.10' : {
+    cves: ['CVE-2026-53914'],
+    description: 'FP: the report only affects org.jetbrains.kotlin:kotlin-gradle-plugin, the CPE for the kotlin product matches any kotlin artifact. We ship kotlin-stdlib as a transitive dependency of the webpush library, not the gradle plugin.'
+  },
   'pkg:maven/com.networknt/json-schema-validator@1.5.9' : {
     cves: ['CVE-2025-15104'],
     description: 'FP: The CVE belongs to Nu Html Checker which produce a false positive on Networknt JSON Schema Validator due to the overlapping keyword or an overly broad CPE mapping rule.'

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -16,6 +16,10 @@
 {{javadeps}}
         <slf4j.version>2.0.17</slf4j.version>
         <jna.version>5.18.1</jna.version>
+        <!-- Security overrides: force fixed transitive versions -->
+        <spring.framework.security.version>7.0.9</spring.framework.security.version>
+        <micrometer.security.version>1.17.1</micrometer.security.version>
+        <tomcat.security.version>11.0.25</tomcat.security.version>
     </properties>
 
     <distributionManagement>
@@ -27,6 +31,47 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--
+             Security overrides. These force fixed transitive versions ahead of
+             Spring Boot / Flow / Hilla / kits management. Declared first so that
+             they win over the versions coming from the imported BOMs. Remove
+             each one once the upstream ships the fixed version.
+            -->
+            <!-- spring framework, CVE-2026-41838 to CVE-2026-41855.
+                 observability-kit-spring pulls spring-context 7.0.7 while the
+                 rest of the spring modules resolve to 7.0.9 -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.framework.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- micrometer, CVE-2026-40983, CVE-2026-40984.
+                 observability-kit-micrometer pulls micrometer 1.16.4 -->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>${micrometer.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- tomcat embed, CVE-2026-66299 -->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-el</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-websocket</artifactId>
+                <version>${tomcat.security.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>vaadin-spring-bom</artifactId>


### PR DESCRIPTION
## Summary

- Update `spring.boot.version` from 4.1.0 to 4.1.1 in the root pom, which is what `vaadin-spring-boot-starter` ships.
- Acknowledge the two kotlin entries in the SBOM check whitelist.

## Context

The SBOM check has been red on every PR for the last week. Resolving the `vaadin-platform-sbom` module on a clean clone reproduces it, and the reported versions come from three different places.

Spring Boot 4.1.1 pins tomcat 11.0.24 (was 11.0.22), log4j2 2.25.5 (was 2.25.4), spring-framework 7.0.9 and micrometer 1.17.1. Verified with `mvn -Psbom -pl vaadin-platform-sbom dependency:tree` before and after the change:

```
org.apache.logging.log4j:log4j-to-slf4j:jar:2.25.4  ->  2.25.5
org.apache.tomcat.embed:tomcat-embed-core:jar:11.0.22  ->  11.0.24
```

CVE-2026-53914 is reported against `kotlin-reflect` and `kotlin-stdlib`, but per the advisory it only applies to `org.jetbrains.kotlin:kotlin-gradle-plugin`, which we do not ship. The `jetbrains:kotlin` CPE matches every kotlin artifact, so the entries are added with that reasoning, the same way the other tool driven reports are handled in that file.

Two reports are left after this, and neither can be addressed here:

- `micrometer-core/jetty11/jetty12` 1.16.4 and `spring-context` 7.0.7 are hard pinned by `observability-kit-micrometer` and `observability-kit-spring` 5.0.0-alpha1. The kit main branch already uses micrometer 1.17.0 and spring-context 7.0.8, so this clears once the kit publishes a new release and versions.json points at it: vaadin/observability-kit#369
- CVE-2026-66299 needs tomcat 11.0.25, which no Spring Boot release pins yet. It covers the WebSocket examples webapp, which is not part of tomcat-embed-core.