### PR TITLE
chore: update Spring Boot to 4.1.1 and tomcat to 11.0.25 [25.2]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <spring.boot.version>4.1.0</spring.boot.version>
+        <spring.boot.version>4.1.1</spring.boot.version>
         <jakarta.ee.version>11.0.0</jakarta.ee.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <jetty.version>12.0.22</jetty.version>

--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -121,6 +121,10 @@ const cveWhiteList = {
     cves: ['CVE-2026-54285'],
     description: 'Not affected: @opentelemetry/core is a transitive dep of the browser Web SDK and is used only to ORIGINATE spans. The vulnerable W3CBaggagePropagator.extract() (inbound untrusted baggage parsing) is never on the execution path. vulnerable_code_not_in_execute_path.'
   },
+  'pkg:npm/%40opentelemetry/core@1.8.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'Not affected: @opentelemetry/core is a transitive dep of the browser Web SDK and is used only to ORIGINATE spans. The vulnerable W3CBaggagePropagator.extract() (inbound untrusted baggage parsing) is never on the execution path. vulnerable_code_not_in_execute_path.'
+  },
   'pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.22.1' : {
     cves: ['CVE-2026-54515'],
     description: 'Not affected: Vaadin and Hilla deserialize endpoint input with the default Jackson mapper. The bypass requires MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, which Vaadin does not enable (verified in Hilla JacksonObjectMapperFactory). vulnerable_code_not_in_execute_path. Tracked upstream in vaadin/hilla#5801 and vaadin/appsec-kit#238.'

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -18,7 +18,7 @@
         <jna.version>5.18.1</jna.version>
         <!-- Security overrides: force fixed transitive versions -->
         <logback.security.version>1.5.35</logback.security.version>
-        <tomcat.security.version>11.0.24</tomcat.security.version>
+        <tomcat.security.version>11.0.25</tomcat.security.version>
         <jackson2.security.version>2.22.1</jackson2.security.version>
         <jackson3.security.version>3.1.5</jackson3.security.version>
         <kotlin.security.version>2.4.0</kotlin.security.version>


### PR DESCRIPTION
## Summary

Three small version and configuration updates needed before cutting 25.2.7.

- `spring.boot.version` 4.1.0 to 4.1.1, which manages log4j2 2.25.5 instead of 2.25.4.
- `tomcat.security.version` 11.0.24 to 11.0.25 in the vaadin-bom template, the latest 11.0.x patch.
- Added the unescaped slash form of the `@opentelemetry/core` 1.8.0 purl to the check list in `generateAndCheckSBOM.js`.

## Context

The scanner emits `pkg:npm/%40opentelemetry/core@1.8.0` with the slash unescaped, while the list only had `%2Fcore@1.8.0` and the unescaped form for 1.9.0. Both entries describe the same report with the same reasoning, so the 1.8.0 one simply never matched. Adding the missing form keeps the two versions treated consistently.

The Spring Boot and tomcat parts mirror what already landed on main in #9314.