### PR TITLE
chore: stop managing kotlin versions in vaadin-bom

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -135,7 +135,11 @@ const cveWhiteList = {
   },
   'pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@2.4.0' : {
     cves: ['CVE-2026-53914'],
-    description: 'False positive: osv.dev reports kotlin-stdlib 2.4.0 as not affected. owasp flags it via imprecise CPE matching. Tracked upstream in vaadin/flow#24962 and vaadin/hilla#5801.'
+    description: 'False positive: osv.dev reports kotlin-stdlib 2.4.0 as not affected. owasp flags it via imprecise CPE matching. kotlin-stdlib comes from flow-webpush, which already declares 2.4.0.'
+  },
+  'pkg:maven/org.jetbrains.kotlin/kotlin-reflect@2.1.21' : {
+    cves: ['CVE-2026-53914'],
+    description: 'False positive: the report only affects org.jetbrains.kotlin:kotlin-gradle-plugin, and the CPE for the kotlin product matches any kotlin artifact. We ship kotlin-reflect as a transitive dependency of hilla-typescript-generator, not the gradle plugin. osv.dev reports kotlin-reflect 2.1.21 as not affected.'
   },
 }
 

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -21,7 +21,6 @@
         <tomcat.security.version>11.0.25</tomcat.security.version>
         <jackson2.security.version>2.22.1</jackson2.security.version>
         <jackson3.security.version>3.1.5</jackson3.security.version>
-        <kotlin.security.version>2.4.0</kotlin.security.version>
     </properties>
 
     <distributionManagement>
@@ -52,14 +51,6 @@
                 <groupId>tools.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson3.security.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- kotlin, CVE-2026-53914 -->
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-bom</artifactId>
-                <version>${kotlin.security.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Summary

- Remove the `kotlin-bom` import and the `kotlin.security.version` property from `template-vaadin-bom.xml`.
- Acknowledge `kotlin-reflect@2.1.21`, the version that resolves once the override is gone, in the SBOM check list.

## Context

The kotlin import manages every kotlin artifact, not just the two we ship transitively, and it is declared before the spring boot import, so it wins for any consumer that imports `vaadin-bom` first. Same pom with only the bom version changed, spring boot 4.1.1 imported after it: 25.1.11 resolves kotlin 2.3.21, 25.2.6 resolves 2.4.0. A customer hit this going from 25.1.5 to 25.2.3.

Removing it lowers nothing. `mvn -Psbom -pl vaadin-platform-sbom dependency:tree` after the change gives `kotlin-stdlib` 2.4.0, which `flow-webpush` already declares, and `kotlin-reflect` 2.1.21 from `hilla-typescript-generator`. osv.dev reports neither as affected. Main already handles the kotlin reports through the check list only, in #9314.

The SBOM job stays red on three reports that predate this branch state, opentelemetry-api, opentelemetry-common and json-schema-ref-parser. They are handled separately.