### PR TITLE
chore: acknowledge two SBOM reports that do not apply

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -56,6 +56,14 @@ const licenseWhiteList = [
 const coreLicensesWhiteList = licenseWhiteList.toSpliced(licenseWhiteList.indexOf(VAADIN_LICENSE),1);
 
 const cveWhiteList = {
+  'pkg:maven/io.opentelemetry/opentelemetry-api@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom transitively through selenium-remote-driver under vaadin-testbench, a test only dependency.'
+  },
+  'pkg:npm/%40apidevtools/json-schema-ref-parser@11.7.2' : {
+    cves: ['CVE-2026-15195'],
+    description: 'The cve carries a git only range with no version mapping. The affected releases are 15.3.0 to 15.3.5, fixed in 15.3.6, while 11.7.2 predates that line by 17 months. It arrives through swagger-parser 10.1.1, which pins it exactly.'
+  },
   'pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.4' : {
     cves: ['CVE-2023-35116'],
     description: 'Not a valid CVE report based on the vendor analysis and [research](https://github.com/FasterXML/jackson-databind/issues/3972)'


### PR DESCRIPTION
## Summary

* Acknowledge `io.opentelemetry:opentelemetry-api@1.64.0` for `CVE-2026-54285`. The advisory is for `opentelemetry-js` and the CPE that matched carries `node.js` as its target software, so it does not apply to the Java artifact. It reaches the sbom module only through `selenium-remote-driver` under `vaadin-testbench`, a test scoped path.
* Acknowledge `@apidevtools/json-schema-ref-parser@11.7.2` for `CVE-2026-15195`. The advisory carries a git only range with no ecosystem mapping, and the releases OSV lists as affected are 15.3.0 to 15.3.5, fixed in 15.3.6. Version 11.7.2 was published in October 2024, seventeen months before that line existed. It arrives through `@apidevtools/swagger-parser@10.1.1`, which pins it exactly, so a bump is not available either.

## Context

Both are reported as blocking, and the sbom check is blocking for the stable release flow, so they stop any stable release on this branch. Same change on main, 25.2, 25.1, 24.10 and 24.9, which are the branches whose trees actually carry these two versions: 23.6 and 23.7 resolve selenium 4.44.0 with opentelemetry 1.62.0 and pin no Hilla, so neither entry applies there.
