### PR TITLE
chore: Update flow-cdi to 16.1.2 and vaadin-quarkus to 3.2.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -127,7 +127,7 @@
             "javaVersion": "25.3.0-alpha9"
         },
         "flow-cdi": {
-            "javaVersion": "16.1.1"
+            "javaVersion": "16.1.2"
         },
         "flow-components": {
             "javaVersion": "{{version}}"

--- a/versions.json
+++ b/versions.json
@@ -349,7 +349,7 @@
             "javaVersion": "{{version}}"
         },
         "vaadin-quarkus": {
-            "javaVersion": "3.2.1"
+            "javaVersion": "3.2.2"
         },
         "vaadin-renderer": {
             "javaVersion": "{{version}}"


### PR DESCRIPTION
## Summary

- flow-cdi 16.1.1 to 16.1.2
- vaadin-quarkus 3.2.1 to 3.2.2

## Context

Both bumps travel together so they take a single validation cycle. Replaces #9363.
