### PR TITLE
chore: Update browserless-test to 1.2.0-beta1 and observability-kit-starter to 5.0.0-beta1

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -41,7 +41,7 @@
             "npmName": "@vaadin/breadcrumbs"
         },
         "browserless-test": {
-            "javaVersion": "1.2.0-alpha2"
+            "javaVersion": "1.2.0-beta1"
         },
         "button": {
             "jsVersion": "25.3.0-beta1",

--- a/versions.json
+++ b/versions.json
@@ -393,7 +393,7 @@
             "javaVersion": "3.1.1"
         },
         "observability-kit-starter": {
-            "javaVersion": "5.0.0-alpha1"
+            "javaVersion": "5.0.0-beta1"
         },
         "sso-kit-starter": {
             "javaVersion": "4.1.3",


### PR DESCRIPTION
## Summary

- browserless-test 1.2.0-alpha2 to 1.2.0-beta1
- observability-kit-starter 5.0.0-alpha1 to 5.0.0-beta1

## Context

A beta cannot ship alpha pins. Both versions are published and verified in Maven Central, and both carry their tag and GitHub release. Neither component's release build opens this PR, so the two pins travel together to spend a single validation cycle.
