### PR TITLE
[WIP] chore: align spring framework and spring security with the managed versions

### DIFF
--- a/scripts/generateAndCheckSBOM.js
+++ b/scripts/generateAndCheckSBOM.js
@@ -61,6 +61,54 @@ const cveWhiteList = {
     cves: ['CVE-2026-54285'],
     description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom transitively through selenium-remote-driver under vaadin-testbench, a test only dependency.'
   },
+  // The rest of the OpenTelemetry Java family, same CPE mismatch. The matched CPE is
+  // cpe:2.3:a:opentelemetry:opentelemetry:*:*:*:*:*:node.js:*:* and these are Maven
+  // artifacts. Two paths bring them in: observability-kit-starter uses the Java SDK at
+  // 1.62.0, and selenium-remote-driver under vaadin-testbench brings the 1.64.0 line.
+  'pkg:maven/io.opentelemetry/opentelemetry-api@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-common@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-logs@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-metrics@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-trace@1.62.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom through observability-kit-starter, which uses the OpenTelemetry Java SDK.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-common@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom transitively through selenium-remote-driver under vaadin-testbench, a test only dependency.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-context@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It reaches the sbom transitively through selenium-remote-driver under vaadin-testbench, a test only dependency.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-exporter-logging@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It is part of the OpenTelemetry Java SDK pulled in by observability-kit-starter.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It is part of the OpenTelemetry Java SDK pulled in by observability-kit-starter.'
+  },
+  'pkg:maven/io.opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi@1.64.0' : {
+    cves: ['CVE-2026-54285'],
+    description: 'False positive: the advisory is for opentelemetry-js and the CPE that matched targets node.js, not the Java artifact. It is part of the OpenTelemetry Java SDK pulled in by observability-kit-starter.'
+  },
   'pkg:npm/%40apidevtools/json-schema-ref-parser@11.7.2' : {
     cves: ['CVE-2026-15195'],
     description: 'The cve carries a git only range with no version mapping. The affected releases are 15.3.0 to 15.3.5, fixed in 15.3.6, while 11.7.2 predates that line by 17 months. It arrives through swagger-parser 10.1.1, which pins it exactly.'

--- a/scripts/generator/templates/template-vaadin-bom.xml
+++ b/scripts/generator/templates/template-vaadin-bom.xml
@@ -21,6 +21,8 @@
         <tomcat.security.version>11.0.25</tomcat.security.version>
         <jackson2.security.version>2.22.1</jackson2.security.version>
         <jackson3.security.version>3.1.5</jackson3.security.version>
+        <spring.framework.security.version>7.0.9</spring.framework.security.version>
+        <spring.security.security.version>7.1.1</spring.security.security.version>
     </properties>
 
     <distributionManagement>
@@ -80,6 +82,22 @@
                 <groupId>org.apache.tomcat.embed</groupId>
                 <artifactId>tomcat-embed-websocket</artifactId>
                 <version>${tomcat.security.version}</version>
+            </dependency>
+            <!-- spring framework, CVE-2026-47890/47891/47892/47893/59280/59281/59282/59283/59313/59314 -->
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.framework.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- spring security, CVE-2026-47841/47842/47877/59270/59276/59277 -->
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring.security.security.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Summary

- Pin `spring-framework-bom` to 7.0.9 and `spring-security-bom` to 7.1.1 in the vaadin-bom security override block, which are the versions spring-boot 4.1.1 already manages
- Unify the eight spring-security artifacts, which resolved across two lines, 7.1.0 and 7.0.6
- Acknowledge the remaining opentelemetry java artifacts in the sbom check list

## Context

Three of our own components each brought a different spring line: `vaadin-spring 25.2.8` brings `spring-webmvc 7.0.8`, `hilla-endpoint 25.2.8` brings `spring-security 7.1.0`, and `sso-kit-core 4.1.3` brings `spring-security 7.0.6`. The last one imports its own `spring-boot-dependencies 4.0.7`, which is why platform's own 4.1.1 did not win.

Resolved tree before and after, 18 artifacts change version and none is added or removed. The two changes beyond spring are what spring-security 7.1.1 pins itself: `micrometer` 1.16.6 to 1.16.7 and `oauth2-oidc-sdk` 11.26.1 to 11.38.2.
